### PR TITLE
Add role-based registration and password strength validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+frontend-auth/node_modules
+backend-auth/node_modules

--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "backend-auth",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.21.1",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1,0 +1,68 @@
+import express from 'express';
+import cors from 'cors';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// Usuarios almacenados en memoria para ejemplo
+const usuarios = [];
+
+const CODIGO_DELEGADO = process.env.CODIGO_DELEGADO || 'DEL123';
+const CODIGO_TECNICO = process.env.CODIGO_TECNICO || 'TEC456';
+const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
+
+const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
+
+app.post('/api/auth/registro', (req, res) => {
+  const { nombre, apellido, email, password, confirmarPassword, rol, codigo } = req.body;
+
+  if (!nombre || !apellido || !email || !password || !confirmarPassword || !rol) {
+    return res.status(400).json({ mensaje: 'Faltan datos' });
+  }
+  if (password !== confirmarPassword) {
+    return res.status(400).json({ mensaje: 'Las contraseñas no coinciden' });
+  }
+  if (!passwordRegex.test(password)) {
+    return res.status(400).json({
+      mensaje: 'La contraseña debe tener al menos 8 caracteres, incluir mayúsculas, minúsculas, números y un carácter especial.'
+    });
+  }
+  if (rol === 'delegado' && codigo !== CODIGO_DELEGADO) {
+    return res.status(400).json({ mensaje: 'Código de delegado incorrecto' });
+  }
+  if (rol === 'tecnico' && codigo !== CODIGO_TECNICO) {
+    return res.status(400).json({ mensaje: 'Código de técnico incorrecto' });
+  }
+
+  const existe = usuarios.find((u) => u.email === email);
+  if (existe) {
+    return res.status(400).json({ mensaje: 'El email ya está registrado' });
+  }
+
+  const hashed = bcrypt.hashSync(password, 10);
+  const usuario = { id: usuarios.length + 1, nombre, apellido, email, password: hashed, rol };
+  usuarios.push(usuario);
+  return res.status(201).json({ mensaje: 'Usuario registrado con éxito' });
+});
+
+app.post('/api/auth/login', (req, res) => {
+  const { email, password } = req.body;
+  const usuario = usuarios.find((u) => u.email === email);
+  if (!usuario) {
+    return res.status(400).json({ mensaje: 'Credenciales inválidas' });
+  }
+  const valido = bcrypt.compareSync(password, usuario.password);
+  if (!valido) {
+    return res.status(400).json({ mensaje: 'Credenciales inválidas' });
+  }
+  const token = jwt.sign({ id: usuario.id, rol: usuario.rol }, JWT_SECRET, { expiresIn: '1h' });
+  return res.json({ token, usuario: { nombre: usuario.nombre, rol: usuario.rol, foto: '' } });
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Servidor escuchando en puerto ${PORT}`);
+});

--- a/frontend-auth/src/components/FotoUploader.jsx
+++ b/frontend-auth/src/components/FotoUploader.jsx
@@ -23,6 +23,7 @@ export default function FotoUploader() {
       localStorage.setItem('foto', res.data.foto);
       window.location.reload();
     } catch (err) {
+      console.error(err);
       alert('Error al subir la foto');
     }
   };

--- a/frontend-auth/src/components/RegisterForm.jsx
+++ b/frontend-auth/src/components/RegisterForm.jsx
@@ -4,7 +4,15 @@ import { useNavigate } from 'react-router-dom';
 
 export default function RegisterForm() {
   const [mensaje, setMensaje] = useState('');
+  const [rol, setRol] = useState('');
+  const [codigo, setCodigo] = useState('');
   const navigate = useNavigate();
+
+  const esPasswordSegura = (pwd) => {
+    // Debe tener al menos 8 caracteres, con mayúsculas, minúsculas, números y caracteres especiales
+    const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
+    return regex.test(pwd);
+  };
 
   const handleRegister = async (e) => {
     e.preventDefault();
@@ -15,13 +23,20 @@ export default function RegisterForm() {
     const password = e.target.password.value;
     const confirmarPassword = e.target.confirmarPassword.value;
 
+    if (!esPasswordSegura(password)) {
+      setMensaje('La contraseña debe tener al menos 8 caracteres, incluir mayúsculas, minúsculas, números y un carácter especial.');
+      return;
+    }
+
     try {
       const res = await axios.post('http://localhost:5000/api/auth/registro', {
         nombre,
         apellido,
         email,
         password,
-        confirmarPassword
+        confirmarPassword,
+        rol,
+        codigo
       });
 
       setMensaje(res.data.mensaje);
@@ -34,6 +49,8 @@ export default function RegisterForm() {
     }
   };
 
+  const requiereCodigo = rol === 'delegado' || rol === 'tecnico';
+
   return (
     <div>
       <form onSubmit={handleRegister}>
@@ -42,6 +59,24 @@ export default function RegisterForm() {
         <input type="email" name="email" placeholder="Email" required /><br />
         <input type="password" name="password" placeholder="Contraseña" required /><br />
         <input type="password" name="confirmarPassword" placeholder="Confirmar Contraseña" required /><br />
+        <select name="rol" value={rol} onChange={(e) => setRol(e.target.value)} required>
+          <option value="">Seleccione un rol</option>
+          <option value="delegado">Delegado</option>
+          <option value="tecnico">Técnico</option>
+          <option value="deportista">Deportista</option>
+        </select><br />
+        {requiereCodigo && (
+          <>
+            <input
+              type="text"
+              name="codigo"
+              placeholder="Código especial"
+              value={codigo}
+              onChange={(e) => setCodigo(e.target.value)}
+              required
+            /><br />
+          </>
+        )}
         <button type="submit">Registrarse</button>
       </form>
       {mensaje && <p>{mensaje}</p>}

--- a/frontend-auth/src/pages/Dashboard.jsx
+++ b/frontend-auth/src/pages/Dashboard.jsx
@@ -49,6 +49,7 @@ export default function Dashboard() {
       setFoto(res.data.foto);
       setNuevaFoto(null);
     } catch (err) {
+      console.error(err);
       alert('Error al subir la foto');
     }
   };


### PR DESCRIPTION
## Summary
- allow users to select delegado, técnico or deportista during registration, requiring a special code for delegado or técnico and enforcing strong passwords
- add an Express backend that validates role codes and password complexity before registering a user
- ignore node modules in the repository

## Testing
- `npm test` (frontend) - missing script: "test"
- `npm run lint` (frontend)
- `npm test` (backend) - missing script: "test"
- `node server.js` (backend) - cannot find module 'express'


------
https://chatgpt.com/codex/tasks/task_e_689161cd1c848320b329eb8ac4eb0ed0