### PR TITLE
feat: store users in mongodb

### DIFF
--- a/backend-auth/models/User.js
+++ b/backend-auth/models/User.js
@@ -1,20 +1,24 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-const userSchema = new mongoose.Schema({
-  nombre: { type: String, required: true },
-  apellido: { type: String, required: true },
-  email: { type: String, required: true, unique: true },
- password: {
-  type: String,
-  required: function () {
-    return !this.googleId;
-  }
-},
-rol: { type: String, enum: ['Delegado', 'Tecnico', 'Deportista'], default: 'Deportista' },
-confirmado: { type: Boolean, default: false },
-  tokenConfirmacion: { type: String },
-  googleId: { type: String }, // por si se loguea con Google
-  foto: { type: String },
-}, { timestamps: true });
+const userSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true },
+    apellido: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: {
+      type: String,
+      required: function () {
+        return !this.googleId;
+      }
+    },
+    rol: { type: String, enum: ['Delegado', 'Tecnico', 'Deportista'], default: 'Deportista' },
+    confirmado: { type: Boolean, default: false },
+    tokenConfirmacion: { type: String },
+    googleId: { type: String }, // por si se loguea con Google
+    foto: { type: String }
+  },
+  { timestamps: true }
+);
 
-module.exports = mongoose.model('User', userSchema);
+const User = mongoose.model('User', userSchema);
+export default User;

--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -10,6 +10,7 @@
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "express": "^4.21.1",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^7.6.0"
   }
 }

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -2,39 +2,33 @@ import express from 'express';
 import cors from 'cors';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import fs from 'fs/promises';
+import mongoose from 'mongoose';
+import fs from 'fs';
+import path from 'path';
+import User from './models/User.js';
+
+// Cargar variables de entorno desde .env si está presente
+const envPath = path.resolve('.env');
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf8');
+  envContent.split('\n').forEach((line) => {
+    const match = line.match(/^([^#=]+)=([^]*)$/);
+    if (match) {
+      const key = match[1].trim();
+      const value = match[2].trim();
+      if (!process.env[key]) process.env[key] = value;
+    }
+  });
+}
+
+mongoose
+  .connect(process.env.MONGODB_URI)
+  .then(() => console.log('MongoDB conectado'))
+  .catch((err) => console.error('Error conectando a MongoDB:', err.message));
 
 const app = express();
 app.use(cors());
 app.use(express.json());
-
-const DB_FILE = './usuarios.db';
-
-async function leerUsuarios() {
-  try {
-    const data = await fs.readFile(DB_FILE, 'utf8');
-    return JSON.parse(data);
-  } catch (err) {
-    if (err.code === 'ENOENT') return [];
-    throw err;
-  }
-}
-
-async function guardarUsuarios(usuarios) {
-  await fs.writeFile(DB_FILE, JSON.stringify(usuarios, null, 2));
-}
-
-async function buscarUsuarioPorEmail(email) {
-  const usuarios = await leerUsuarios();
-  return usuarios.find((u) => u.email === email);
-}
-
-async function agregarUsuario(usuario) {
-  const usuarios = await leerUsuarios();
-  const id = usuarios.length > 0 ? Math.max(...usuarios.map((u) => u.id)) + 1 : 1;
-  usuarios.push({ id, ...usuario });
-  await guardarUsuarios(usuarios);
-}
 
 const CODIGO_DELEGADO = process.env.CODIGO_DELEGADO || 'DEL123';
 const CODIGO_TECNICO = process.env.CODIGO_TECNICO || 'TEC456';
@@ -64,19 +58,20 @@ app.post('/api/auth/registro', async (req, res) => {
     return res.status(400).json({ mensaje: 'Código de técnico incorrecto' });
   }
 
-  const existente = await buscarUsuarioPorEmail(email);
+  const existente = await User.findOne({ email });
   if (existente) {
     return res.status(400).json({ mensaje: 'El email ya está registrado' });
   }
 
   const hashed = bcrypt.hashSync(password, 10);
-  await agregarUsuario({ nombre, apellido, email, password: hashed, rol });
+  const rolGuardado = rol.charAt(0).toUpperCase() + rol.slice(1);
+  await User.create({ nombre, apellido, email, password: hashed, rol: rolGuardado });
   return res.status(201).json({ mensaje: 'Usuario registrado con éxito' });
 });
 
 app.post('/api/auth/login', async (req, res) => {
   const { email, password } = req.body;
-  const usuario = await buscarUsuarioPorEmail(email);
+  const usuario = await User.findOne({ email });
   if (!usuario) {
     return res.status(400).json({ mensaje: 'Credenciales inválidas' });
   }
@@ -84,12 +79,12 @@ app.post('/api/auth/login', async (req, res) => {
   if (!valido) {
     return res.status(400).json({ mensaje: 'Credenciales inválidas' });
   }
-  const token = jwt.sign({ id: usuario.id, rol: usuario.rol }, JWT_SECRET, {
+  const token = jwt.sign({ id: usuario._id, rol: usuario.rol }, JWT_SECRET, {
     expiresIn: '1h'
   });
   return res.json({
     token,
-    usuario: { nombre: usuario.nombre, rol: usuario.rol, foto: '' }
+    usuario: { nombre: usuario.nombre, rol: usuario.rol, foto: usuario.foto || '' }
   });
 });
 


### PR DESCRIPTION
## Summary
- connect backend to MongoDB using `MONGODB_URI`
- persist user registration and login with Mongoose model
- load `.env` variables and add Mongoose dependency

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm install mongoose dotenv` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68918843b92c8320ac4135fbfaef0c96