### PR TITLE
Require email confirmation before login

### DIFF
--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -11,6 +11,7 @@
     "cors": "^2.8.5",
     "express": "^4.21.1",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^7.6.0"
+    "mongoose": "^7.6.0",
+    "nodemailer": "^6.9.8"
   }
 }


### PR DESCRIPTION
## Summary
- Add email verification flow: registration now stores a confirmation token, sends email with backend link and requires confirmation before login.
- Implement endpoint to validate token and redirect users to the login page.
- Add nodemailer dependency.

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemailer)*
- `npm test` *(backend) (fails: Missing script "test")*
- `npm test` *(frontend) (fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891ebefd59c83209ee0dd76b519cc80