### PR TITLE
Add protected profile endpoints

### DIFF
--- a/backend-auth/middlewares/authMiddleware.js
+++ b/backend-auth/middlewares/authMiddleware.js
@@ -1,7 +1,6 @@
-// middlewares/authMiddleware.js
-const jwt = require('jsonwebtoken');
+import jwt from 'jsonwebtoken';
 
-exports.protegerRuta = (req, res, next) => {
+export const protegerRuta = (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader?.startsWith('Bearer ')) {
@@ -19,14 +18,11 @@ exports.protegerRuta = (req, res, next) => {
   }
 };
 
-// middlddeware de roles
-
-exports.permitirRol = (...roles) => {
-    return (req, res, next) => {
-      if (!roles.includes(req.usuario.rol)) {
-        return res.status(403).json({ mensaje: 'Acceso denegado: rol insuficiente' });
-      }
-      next();
-    };
+export const permitirRol = (...roles) => {
+  return (req, res, next) => {
+    if (!roles.includes(req.usuario.rol)) {
+      return res.status(403).json({ mensaje: 'Acceso denegado: rol insuficiente' });
+    }
+    next();
   };
-  
+};

--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -12,6 +12,7 @@
     "express": "^4.21.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.0",
-    "nodemailer": "^6.9.8"
+    "nodemailer": "^6.9.8",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/backend-auth/utils/multer.js
+++ b/backend-auth/utils/multer.js
@@ -1,11 +1,11 @@
-const multer = require('multer');
-const path = require('path');
+import multer from 'multer';
+import path from 'path';
 
 const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
+  destination(req, file, cb) {
     cb(null, 'uploads/');
   },
-  filename: function (req, file, cb) {
+  filename(req, file, cb) {
     const ext = path.extname(file.originalname);
     cb(null, `${Date.now()}${ext}`);
   }
@@ -13,4 +13,4 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-module.exports = upload;
+export default upload;


### PR DESCRIPTION
## Summary
- expose `/api/protegido/usuario` to fetch logged-in user info
- allow authenticated profile photo updates via `/api/protegido/foto-perfil`
- convert auth middleware and upload utility to ES modules and add multer dependency

## Testing
- `npm test` (fails: Missing script "test")
- `node server.js` (fails: Cannot find package 'multer')


------
https://chatgpt.com/codex/tasks/task_e_6891f23fc36c8320bb34cbfcc5f4fa0c