### PR TITLE
feat: darken navbar blue and remove repeating gradient

### DIFF
--- a/frontend-auth/src/components/Navbar.css
+++ b/frontend-auth/src/components/Navbar.css
@@ -11,11 +11,11 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  background: repeating-linear-gradient(
+  background: linear-gradient(
     40deg,
-    rgba(13, 202, 240, 0) 0px,
-    rgba(13, 202, 240, 1) 10px,
-    rgba(13, 202, 240, 1) 25px,
+    rgba(13, 162, 220, 0) 0px,
+    rgba(13, 162, 220, 1) 10px,
+    rgba(13, 162, 220, 1) 25px,
     #ffffff 25px,
     #ffffff 40px,
     #008000 40px,
@@ -24,8 +24,8 @@
     #000000 70px,
     rgba(0, 0, 0, 0) 80px
   );
-  animation: navbarLines 4s linear infinite;
-  background-size: 80px 100%;
+  background-repeat: no-repeat;
+  animation: navbarLines 4s linear forwards;
   z-index: 0;
 }
 


### PR DESCRIPTION
## Summary
- remove repeating navbar gradient and darken its blue stripe
- stop navbar animation from looping forever

## Testing
- `npm --prefix frontend-auth test` (fails: Missing script "test")
- `npm --prefix frontend-auth run lint`
- `npm --prefix frontend-auth run build`


------
https://chatgpt.com/codex/tasks/task_e_6892c1618b9c8320a0c47d62d4e61d1c