### PR TITLE
feat: add patinador creation

### DIFF
--- a/backend-auth/models/Patinador.js
+++ b/backend-auth/models/Patinador.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+const patinadorSchema = new mongoose.Schema(
+  {
+    primerNombre: { type: String, required: true },
+    segundoNombre: { type: String },
+    apellido: { type: String, required: true },
+    edad: { type: Number, required: true },
+    fechaNacimiento: { type: Date, required: true },
+    dni: { type: String, required: true, unique: true },
+    cuil: { type: String, required: true, unique: true },
+    direccion: { type: String, required: true },
+    dniMadre: { type: String, required: true },
+    dniPadre: { type: String, required: true },
+    telefono: { type: String, required: true },
+    sexo: { type: String, enum: ['M', 'F'], required: true },
+    nivel: {
+      type: String,
+      enum: ['Escuela', 'Transicion', 'Intermedia', 'Federados'],
+      required: true
+    },
+    numeroCorredor: { type: Number, required: true, unique: true },
+    categoria: { type: String, required: true },
+    fotoRostro: { type: String },
+    foto: { type: String }
+  },
+  { timestamps: true }
+);
+
+const Patinador = mongoose.model('Patinador', patinadorSchema, 'patinadors');
+export default Patinador;

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -8,6 +8,7 @@ import path from 'path';
 import crypto from 'crypto';
 import nodemailer from 'nodemailer';
 import User from './models/User.js';
+import Patinador from './models/Patinador.js';
 import { protegerRuta } from './middlewares/authMiddleware.js';
 import upload from './utils/multer.js';
 
@@ -163,6 +164,68 @@ app.post(
     } catch (err) {
       console.error(err);
       res.status(500).json({ mensaje: 'Error al actualizar la foto' });
+    }
+  }
+);
+
+app.post(
+  '/api/patinadores',
+  protegerRuta,
+  upload.fields([
+    { name: 'fotoRostro', maxCount: 1 },
+    { name: 'foto', maxCount: 1 }
+  ]),
+  async (req, res) => {
+    try {
+      const {
+        primerNombre,
+        segundoNombre,
+        apellido,
+        edad,
+        fechaNacimiento,
+        dni,
+        cuil,
+        direccion,
+        dniMadre,
+        dniPadre,
+        telefono,
+        sexo,
+        nivel,
+        numeroCorredor,
+        categoria
+      } = req.body;
+
+      const fotoRostroFile = req.files?.fotoRostro?.[0];
+      const fotoFile = req.files?.foto?.[0];
+
+      const patinador = await Patinador.create({
+        primerNombre,
+        segundoNombre,
+        apellido,
+        edad,
+        fechaNacimiento,
+        dni,
+        cuil,
+        direccion,
+        dniMadre,
+        dniPadre,
+        telefono,
+        sexo,
+        nivel,
+        numeroCorredor,
+        categoria,
+        fotoRostro: fotoRostroFile
+          ? `${req.protocol}://${req.get('host')}/uploads/${fotoRostroFile.filename}`
+          : undefined,
+        foto: fotoFile
+          ? `${req.protocol}://${req.get('host')}/uploads/${fotoFile.filename}`
+          : undefined
+      });
+
+      res.status(201).json(patinador);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ mensaje: 'Error al crear el patinador' });
     }
   }
 );

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from './pages/Dashboard';
 import ProtectedRoute from './components/ProtectedRoute';
 import PanelAdmin from './pages/PanelAdmin';
 import Navbar from './components/Navbar';
+import CargarPatinador from './pages/CargarPatinador';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -21,6 +22,7 @@ function AppRoutes() {
         <Route path="/" element={<Home />} />
         <Route path="/google-success" element={<GoogleSuccess />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+        <Route path="/cargar-patinador" element={<ProtectedRoute><CargarPatinador /></ProtectedRoute>} />
         <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />
       </Routes>
     </>

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -14,13 +14,15 @@ export default function Navbar() {
     { label: 'Servicios', path: '/servicios' },
     { label: 'Gestionar Servicios', path: '/admin/servicios' },
     { label: 'Turnos', path: '/turnos' },
-    { label: 'Gestionar Turnos', path: '/admin/turnos' }
+    { label: 'Gestionar Turnos', path: '/admin/turnos' },
+    { label: 'Cargar Patinador', path: '/cargar-patinador' }
   ];
 
   const itemsUsuario = [
     { label: 'Servicios', path: '/servicios' },
     { label: 'Mis Turnos', path: '/mis-turnos' },
-    { label: 'Contacto', path: '/contacto' }
+    { label: 'Contacto', path: '/contacto' },
+    { label: 'Cargar Patinador', path: '/cargar-patinador' }
   ];
 
   const handleNavigate = (path) => navigate(path);

--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function CargarPatinador() {
+  const [mensaje, setMensaje] = useState('');
+  const [fotoRostro, setFotoRostro] = useState(null);
+  const [foto, setFoto] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const formData = new FormData();
+    formData.append('primerNombre', form.primerNombre.value);
+    formData.append('segundoNombre', form.segundoNombre.value);
+    formData.append('apellido', form.apellido.value);
+    formData.append('edad', form.edad.value);
+    formData.append('fechaNacimiento', form.fechaNacimiento.value);
+    formData.append('dni', form.dni.value);
+    formData.append('cuil', form.cuil.value);
+    formData.append('direccion', form.direccion.value);
+    formData.append('dniMadre', form.dniMadre.value);
+    formData.append('dniPadre', form.dniPadre.value);
+    formData.append('telefono', form.telefono.value);
+    formData.append('sexo', form.sexo.value);
+    formData.append('nivel', form.nivel.value);
+    formData.append('numeroCorredor', form.numeroCorredor.value);
+    formData.append('categoria', form.categoria.value);
+    if (fotoRostro) formData.append('fotoRostro', fotoRostro);
+    if (foto) formData.append('foto', foto);
+
+    try {
+      const token = localStorage.getItem('token');
+      await axios.post('http://localhost:5000/api/patinadores', formData, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'multipart/form-data'
+        }
+      });
+      setMensaje('Patinador creado correctamente');
+      form.reset();
+      setFotoRostro(null);
+      setFoto(null);
+    } catch (err) {
+      console.error(err);
+      setMensaje(err.response?.data?.mensaje || 'Error al crear el patinador');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Cargar Patinador</h1>
+      <form onSubmit={handleSubmit}>
+        <div className="row g-3">
+          <div className="col-md-6">
+            <label className="form-label">Primer Nombre</label>
+            <input type="text" className="form-control" name="primerNombre" required />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Segundo Nombre</label>
+            <input type="text" className="form-control" name="segundoNombre" />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Apellido</label>
+            <input type="text" className="form-control" name="apellido" required />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label">Edad</label>
+            <input type="number" className="form-control" name="edad" required />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label">Fecha de Nacimiento</label>
+            <input type="date" className="form-control" name="fechaNacimiento" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">DNI</label>
+            <input type="text" className="form-control" name="dni" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">CUIL</label>
+            <input type="text" className="form-control" name="cuil" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Dirección</label>
+            <input type="text" className="form-control" name="direccion" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">DNI Madre</label>
+            <input type="text" className="form-control" name="dniMadre" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">DNI Padre</label>
+            <input type="text" className="form-control" name="dniPadre" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Teléfono</label>
+            <input type="text" className="form-control" name="telefono" required />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Sexo</label>
+            <select className="form-select" name="sexo" required>
+              <option value="">Seleccione</option>
+              <option value="M">M</option>
+              <option value="F">F</option>
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Nivel</label>
+            <select className="form-select" name="nivel" required>
+              <option value="">Seleccione</option>
+              <option value="Escuela">Escuela</option>
+              <option value="Transicion">Transición</option>
+              <option value="Intermedia">Intermedia</option>
+              <option value="Federados">Federados</option>
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Número de Corredor</label>
+            <input type="number" className="form-control" name="numeroCorredor" required />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Categoría</label>
+            <input type="text" className="form-control" name="categoria" required />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Foto Rostro</label>
+            <input
+              type="file"
+              className="form-control"
+              accept="image/*"
+              onChange={(e) => setFotoRostro(e.target.files[0])}
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Foto Completa</label>
+            <input
+              type="file"
+              className="form-control"
+              accept="image/*"
+              onChange={(e) => setFoto(e.target.files[0])}
+            />
+          </div>
+        </div>
+        <div className="mt-4">
+          <button type="submit" className="btn btn-primary">Guardar</button>
+        </div>
+      </form>
+      {mensaje && <div className="alert alert-info mt-3">{mensaje}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Patinador mongoose model and creation API with image upload
- create Cargar Patinador page and navigation entry

## Testing
- `npm test` (backend-auth) *(fails: missing script)*
- `npm test` (frontend-auth) *(fails: missing script)*
- `npm run lint` (frontend-auth)

------
https://chatgpt.com/codex/tasks/task_e_6893133aa2548320b8a0e8f06c6323c1