### PR TITLE
fix: attach auth token in patinadores requests

### DIFF
--- a/frontend-auth/.env.example
+++ b/frontend-auth/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/frontend-auth/.gitignore
+++ b/frontend-auth/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/frontend-auth/src/api.js
+++ b/frontend-auth/src/api.js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+// Axios instance that automatically attaches the JWT token from localStorage
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api'
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/frontend-auth/src/components/LoginForm.jsx
+++ b/frontend-auth/src/components/LoginForm.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../api.js';
 
 export default function LoginForm() {
   const handleLogin = async (e) => {
@@ -6,8 +6,8 @@ export default function LoginForm() {
     const email = e.target.email.value;
     const password = e.target.password.value;
 
-    try {
-      const res = await axios.post('http://localhost:5000/api/auth/login', { email, password });
+      try {
+        const res = await api.post('/auth/login', { email, password });
 
       const { token, usuario } = res.data;
 

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from '../api.js';
 import LogoutButton from './LogoutButton';
 
 export default function Navbar() {
@@ -32,18 +32,16 @@ export default function Navbar() {
     if (!file) return;
     const formData = new FormData();
     formData.append('foto', file);
-    try {
-      const token = localStorage.getItem('token');
-      const res = await axios.post(
-        'http://localhost:5000/api/protegido/foto-perfil',
-        formData,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'multipart/form-data'
+      try {
+        const res = await api.post(
+          '/protegido/foto-perfil',
+          formData,
+          {
+            headers: {
+              'Content-Type': 'multipart/form-data'
+            }
           }
-        }
-      );
+        );
       localStorage.setItem('foto', res.data.foto);
       window.location.reload();
     } catch (err) {

--- a/frontend-auth/src/components/RegisterForm.jsx
+++ b/frontend-auth/src/components/RegisterForm.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import api from '../api.js';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -28,8 +28,8 @@ export default function RegisterForm() {
       return;
     }
 
-    try {
-      const res = await axios.post('http://localhost:5000/api/auth/registro', {
+      try {
+        const res = await api.post('/auth/registro', {
         nombre,
         apellido,
         email,

--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import axios from 'axios';
+import api from '../api.js';
 
 export default function CargarPatinador() {
   const [mensaje, setMensaje] = useState('');
@@ -29,10 +29,8 @@ export default function CargarPatinador() {
     if (foto) formData.append('foto', foto);
 
     try {
-      const token = localStorage.getItem('token');
-      await axios.post('http://localhost:5000/api/patinadores', formData, {
+      await api.post('/patinadores', formData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'multipart/form-data'
         }
       });

--- a/frontend-auth/src/pages/Dashboard.jsx
+++ b/frontend-auth/src/pages/Dashboard.jsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
 import LogoutButton from '../components/LogoutButton';
-import axios from 'axios';
+import api from '../api.js';
 
 export default function Dashboard() {
   const [rol, setRol] = useState('');
   const [foto, setFoto] = useState('');
   const [usuario, setUsuario] = useState({});
-
-  const token = localStorage.getItem('token');
 
   useEffect(() => {
     setRol(localStorage.getItem('rol'));
@@ -16,9 +14,7 @@ export default function Dashboard() {
     // Podés cargar más info si querés desde el backend
     const cargarDatos = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/protegido/usuario', {
-          headers: { Authorization: `Bearer ${token}` }
-        });
+        const res = await api.get('/protegido/usuario');
         setUsuario(res.data.usuario);
       } catch (err) {
         console.log(err);
@@ -26,7 +22,7 @@ export default function Dashboard() {
     };
 
     cargarDatos();
-  }, [token]);
+  }, []);
 
   const [nuevaFoto, setNuevaFoto] = useState(null);
 
@@ -37,9 +33,8 @@ export default function Dashboard() {
     formData.append('foto', nuevaFoto);
 
     try {
-      const res = await axios.post('http://localhost:5000/api/protegido/foto-perfil', formData, {
+      const res = await api.post('/protegido/foto-perfil', formData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'multipart/form-data'
         }
       });

--- a/frontend-auth/src/pages/PanelAdmin.jsx
+++ b/frontend-auth/src/pages/PanelAdmin.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api.js';
 import LogoutButton from '../components/LogoutButton';
 
 export default function PanelAdmin() {
@@ -7,12 +7,7 @@ export default function PanelAdmin() {
 
   useEffect(() => {
     const fetchUsuarios = async () => {
-      const token = localStorage.getItem('token');
-      const res = await axios.get('http://localhost:5000/api/protegido/usuarios', {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
+      const res = await api.get('/protegido/usuarios');
       setUsuarios(res.data);
     };
 


### PR DESCRIPTION
## Summary
- centralize axios configuration to send token from localStorage
- use shared axios instance across the frontend and document API URL env

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689460a67f748320a3d73d4551e7251a