### PR TITLE
chore: handle unauthorized errors

### DIFF
--- a/frontend-auth/src/api.js
+++ b/frontend-auth/src/api.js
@@ -13,4 +13,18 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Si el servidor responde 401, limpiamos los datos y redirigimos al inicio
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('rol');
+      localStorage.removeItem('foto');
+      window.location.href = '/';
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;


### PR DESCRIPTION
## Summary
- redirect to login on 401 responses

## Testing
- `npm test` *(frontend-auth)*
- `npm test` *(backend-auth)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed99887083209cbb6b6971ff4e80