### PR TITLE
fix: use router navigation after login

### DIFF
--- a/frontend-auth/src/components/LoginForm.jsx
+++ b/frontend-auth/src/components/LoginForm.jsx
@@ -1,6 +1,9 @@
 import api from '../api.js';
+import { useNavigate } from 'react-router-dom';
 
 export default function LoginForm() {
+  const navigate = useNavigate();
+
   const handleLogin = async (e) => {
     e.preventDefault();
     const email = e.target.email.value;
@@ -18,7 +21,7 @@ export default function LoginForm() {
 
       alert(`Bienvenido ${usuario.nombre}`);
       // Podés redirigir según el rol si querés
-      window.location.href = '/dashboard';
+      navigate('/dashboard');
     } catch (err) {
       alert(err.response?.data?.mensaje || 'Error al iniciar sesión');
     }


### PR DESCRIPTION
## Summary
- use React Router navigate to move to dashboard after login

## Testing
- `npm test` (frontend-auth) *(fails: Missing script "test")*
- `npm run lint` (frontend-auth)
- `npm test` (backend-auth) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689512a419308320a5910540d91d7f51