### PR TITLE
fix: extend google login session

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -301,10 +301,14 @@ app.get('/api/auth/google/callback', async (req, res) => {
       });
     }
 
+    // Generamos un token con vigencia de 24 horas para evitar que la
+    // sesión de los usuarios que inician con Google se cierre de manera
+    // prematura. De esta forma se mantiene el mismo tiempo de expiración
+    // que en el inicio de sesión tradicional.
     const token = jwt.sign(
       { id: usuario._id, rol: usuario.rol, foto: usuario.foto || '' },
       JWT_SECRET,
-      { expiresIn: '1h' }
+      { expiresIn: '24h' }
     );
 
     res.redirect(`${FRONTEND_URL}/google-success?token=${token}`);


### PR DESCRIPTION
## Summary
- align Google OAuth token expiry with standard login to keep session active for 24h

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895587d3f708320894958387c3ebfad