### PR TITLE
Fix token handling when uploading news

### DIFF
--- a/frontend-auth/src/pages/CrearNoticia.jsx
+++ b/frontend-auth/src/pages/CrearNoticia.jsx
@@ -13,9 +13,7 @@ export default function CrearNoticia() {
       formData.append('imagen', e.target.imagen.files[0]);
     }
     try {
-      await api.post('/news', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' }
-      });
+      await api.post('/news', formData);
       navigate('/home');
     } catch (err) {
       alert(err.response?.data?.mensaje || 'Error al crear la noticia');


### PR DESCRIPTION
## Summary
- ensure news creation request doesn't override axios headers so auth token is sent

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895b43653dc8320b86daf8e05d9a440