### PR TITLE
fix: unify JWT secret and migrate auth modules to ESM

### DIFF
--- a/backend-auth/controllers/authController.js
+++ b/backend-auth/controllers/authController.js
@@ -1,10 +1,14 @@
 // controllers/authController.js
-const User = require('../models/User');
-const bcrypt = require('bcryptjs');
-const crypto = require('crypto');
-const enviarEmailConfirmacion = require('../utils/enviarEmailConfirmacion');
+import User from '../models/User.js';
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+import enviarEmailConfirmacion from '../utils/enviarEmailConfirmacion.js';
+import jwt from 'jsonwebtoken';
 
-exports.registrarUsuario = async (req, res) => {
+// Clave JWT unificada
+const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
+
+export const registrarUsuario = async (req, res) => {
   const { nombre, apellido, email, password, confirmarPassword } = req.body;
 
   if (password !== confirmarPassword) {
@@ -36,7 +40,7 @@ exports.registrarUsuario = async (req, res) => {
 };
 
 // Confirmar cuenta con token
-exports.confirmarCuenta = async (req, res) => {
+export const confirmarCuenta = async (req, res) => {
     const { token } = req.params;
   
     const usuario = await User.findOne({ tokenConfirmacion: token });
@@ -53,8 +57,8 @@ exports.confirmarCuenta = async (req, res) => {
     res.status(200).json({ mensaje: 'Cuenta confirmada. Ya podés iniciar sesión.' });
   };
   
-  // Login de usuario
-exports.loginUsuario = async (req, res) => {
+// Login de usuario
+export const loginUsuario = async (req, res) => {
     const { email, password } = req.body;
   
     const usuario = await User.findOne({ email });
@@ -72,10 +76,9 @@ exports.loginUsuario = async (req, res) => {
       return res.status(401).json({ mensaje: 'Contraseña incorrecta' });
     }
   
-    const jwt = require('jsonwebtoken');
     const token = jwt.sign(
       { id: usuario._id, rol: usuario.rol },
-      process.env.JWT_SECRET,
+      JWT_SECRET,
       { expiresIn: '7d' }
     );
   

--- a/backend-auth/routes/authRoutes.js
+++ b/backend-auth/routes/authRoutes.js
@@ -1,11 +1,17 @@
 // routes/authRoutes.js
-const express = require('express');
+import express from 'express';
+import {
+  registrarUsuario,
+  confirmarCuenta,
+  loginUsuario
+} from '../controllers/authController.js';
+import passport from 'passport';
+import jwt from 'jsonwebtoken';
+
 const router = express.Router();
-const { registrarUsuario } = require('../controllers/authController');
-const { confirmarCuenta } = require('../controllers/authController');
-const { loginUsuario } = require('../controllers/authController');
-const passport = require('passport');
-const jwt = require('jsonwebtoken');
+
+// Clave JWT consistente en toda la app
+const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
 
 router.post('/registro', registrarUsuario);
 router.get('/confirmar/:token', confirmarCuenta);
@@ -30,7 +36,7 @@ router.get('/google/callback',
         rol: req.user.rol,
         foto: req.user.foto
       },
-      process.env.JWT_SECRET,
+      JWT_SECRET,
       { expiresIn: '7d' }
     );
     
@@ -42,4 +48,4 @@ router.get('/google/callback',
 
 
 
-module.exports = router;
+export default router;

--- a/backend-auth/utils/enviarEmailConfirmacion.js
+++ b/backend-auth/utils/enviarEmailConfirmacion.js
@@ -1,5 +1,5 @@
 // utils/enviarEmailConfirmacion.js
-const nodemailer = require('nodemailer');
+import nodemailer from 'nodemailer';
 
 const enviarEmailConfirmacion = async (email, token) => {
   const transporter = nodemailer.createTransport({
@@ -20,4 +20,4 @@ const enviarEmailConfirmacion = async (email, token) => {
   });
 };
 
-module.exports = enviarEmailConfirmacion;
+export default enviarEmailConfirmacion;


### PR DESCRIPTION
## Summary
- migrate legacy auth modules to ES modules
- use a shared JWT secret for signing tokens to avoid invalid token errors
- update Google auth callback to use the same secret

## Testing
- `npm test` *(backend-auth)*
- `npm test` *(frontend-auth)*
- `npm run lint` *(frontend-auth)*

------
https://chatgpt.com/codex/tasks/task_e_6895b6a7b2588320b97982adda969ec1