### PR TITLE
Fix token validation by loading JWT secret at runtime

### DIFF
--- a/backend-auth/middlewares/authMiddleware.js
+++ b/backend-auth/middlewares/authMiddleware.js
@@ -1,7 +1,5 @@
 import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
-
 export const protegerRuta = (req, res, next) => {
   const authHeader = req.headers.authorization;
 
@@ -10,6 +8,7 @@ export const protegerRuta = (req, res, next) => {
   }
 
   const token = authHeader.split(' ')[1];
+  const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
 
   try {
     const decodificado = jwt.verify(token, JWT_SECRET);


### PR DESCRIPTION
## Summary
- Ensure auth middleware reads JWT secret at request time to avoid using default value before env variables load

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896b1315e4083209d146747e6e9b09f