### PR TITLE
Add menu item for Cargar Patinador

### DIFF
--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -42,6 +42,7 @@ export default function Navbar() {
   const navItems = isLoggedIn
     ? [
         { label: 'Inicio', path: '/home' },
+        { label: 'Cargar Patinador', path: '/cargar-patinador' },
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [{ label: 'Crear Noticia', path: '/crear-noticia' }]
           : [])


### PR DESCRIPTION
## Summary
- Show Cargar Patinador link in navbar for authenticated users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b55dd3d4832083a126a488b1cbf1