### PR TITLE
Add patinadores listing page sorted by age

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -242,10 +242,20 @@ app.post(
         return res.status(400).json({ mensaje: `${campo} ya existe` });
       }
 
-      res.status(500).json({ mensaje: 'Error al crear el patinador' });
+  res.status(500).json({ mensaje: 'Error al crear el patinador' });
     }
   }
 );
+
+app.get('/api/patinadores', async (req, res) => {
+  try {
+    const patinadores = await Patinador.find().sort({ edad: 1 });
+    res.json(patinadores);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al obtener patinadores' });
+  }
+});
 
 app.get('/api/news', async (req, res) => {
   try {

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -8,6 +8,7 @@ import PanelAdmin from './pages/PanelAdmin';
 import Navbar from './components/Navbar';
 import CargarPatinador from './pages/CargarPatinador';
 import CrearNoticia from './pages/CrearNoticia';
+import ListaPatinadores from './pages/ListaPatinadores';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -25,6 +26,7 @@ function AppRoutes() {
         <Route path="/google-success" element={<GoogleSuccess />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
         <Route path="/cargar-patinador" element={<ProtectedRoute><CargarPatinador /></ProtectedRoute>} />
+        <Route path="/patinadores" element={<ProtectedRoute><ListaPatinadores /></ProtectedRoute>} />
         <Route
           path="/crear-noticia"
           element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><CrearNoticia /></ProtectedRoute>}

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -42,6 +42,7 @@ export default function Navbar() {
   const navItems = isLoggedIn
     ? [
         { label: 'Inicio', path: '/home' },
+        { label: 'Patinadores', path: '/patinadores' },
         { label: 'Cargar Patinador', path: '/cargar-patinador' },
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [{ label: 'Crear Noticia', path: '/crear-noticia' }]

--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import api from '../api.js';
+
+export default function ListaPatinadores() {
+  const [patinadores, setPatinadores] = useState([]);
+
+  useEffect(() => {
+    const obtenerPatinadores = async () => {
+      try {
+        const res = await api.get('/patinadores');
+        setPatinadores(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    obtenerPatinadores();
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Patinadores</h1>
+      <ul className="list-group">
+        {patinadores.map((p) => (
+          <li
+            key={p._id}
+            className="list-group-item d-flex justify-content-between"
+          >
+            <span>
+              {p.primerNombre} {p.segundoNombre ? `${p.segundoNombre} ` : ''}
+              {p.apellido}
+            </span>
+            <span>{p.edad} años</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add backend endpoint to retrieve patinadores sorted by age
- create Patinadores page and navigation link

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68970133397083209fda1e62c6b24c4f