### PR TITLE
feat: add patinador cards with view/edit/delete

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -257,6 +257,70 @@ app.get('/api/patinadores', async (req, res) => {
   }
 });
 
+app.get('/api/patinadores/:id', async (req, res) => {
+  try {
+    const patinador = await Patinador.findById(req.params.id);
+    if (!patinador) {
+      return res.status(404).json({ mensaje: 'Patinador no encontrado' });
+    }
+    res.json(patinador);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al obtener el patinador' });
+  }
+});
+
+app.put(
+  '/api/patinadores/:id',
+  protegerRuta,
+  upload.fields([
+    { name: 'fotoRostro', maxCount: 1 },
+    { name: 'foto', maxCount: 1 }
+  ]),
+  async (req, res) => {
+    try {
+      const actualizacion = { ...req.body };
+      const fotoRostroFile = req.files?.fotoRostro?.[0];
+      const fotoFile = req.files?.foto?.[0];
+
+      if (fotoRostroFile) {
+        actualizacion.fotoRostro = `${req.protocol}://${req.get('host')}/uploads/${fotoRostroFile.filename}`;
+      }
+      if (fotoFile) {
+        actualizacion.foto = `${req.protocol}://${req.get('host')}/uploads/${fotoFile.filename}`;
+      }
+
+      const patinadorActualizado = await Patinador.findByIdAndUpdate(
+        req.params.id,
+        actualizacion,
+        { new: true, runValidators: true }
+      );
+
+      if (!patinadorActualizado) {
+        return res.status(404).json({ mensaje: 'Patinador no encontrado' });
+      }
+
+      res.json(patinadorActualizado);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ mensaje: 'Error al actualizar el patinador' });
+    }
+  }
+);
+
+app.delete('/api/patinadores/:id', protegerRuta, async (req, res) => {
+  try {
+    const patinador = await Patinador.findByIdAndDelete(req.params.id);
+    if (!patinador) {
+      return res.status(404).json({ mensaje: 'Patinador no encontrado' });
+    }
+    res.json({ mensaje: 'Patinador eliminado' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al eliminar el patinador' });
+  }
+});
+
 app.get('/api/news', async (req, res) => {
   try {
     const noticias = await News.find()

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -9,6 +9,8 @@ import Navbar from './components/Navbar';
 import CargarPatinador from './pages/CargarPatinador';
 import CrearNoticia from './pages/CrearNoticia';
 import ListaPatinadores from './pages/ListaPatinadores';
+import VerPatinador from './pages/VerPatinador';
+import EditarPatinador from './pages/EditarPatinador';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -27,6 +29,8 @@ function AppRoutes() {
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
         <Route path="/cargar-patinador" element={<ProtectedRoute><CargarPatinador /></ProtectedRoute>} />
         <Route path="/patinadores" element={<ProtectedRoute><ListaPatinadores /></ProtectedRoute>} />
+        <Route path="/patinadores/:id" element={<ProtectedRoute><VerPatinador /></ProtectedRoute>} />
+        <Route path="/patinadores/:id/editar" element={<ProtectedRoute><EditarPatinador /></ProtectedRoute>} />
         <Route
           path="/crear-noticia"
           element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><CrearNoticia /></ProtectedRoute>}

--- a/frontend-auth/src/pages/EditarPatinador.jsx
+++ b/frontend-auth/src/pages/EditarPatinador.jsx
@@ -1,0 +1,255 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api.js';
+
+export default function EditarPatinador() {
+  const { id } = useParams();
+  const [mensaje, setMensaje] = useState('');
+  const [patinador, setPatinador] = useState(null);
+  const [fotoRostro, setFotoRostro] = useState(null);
+  const [foto, setFoto] = useState(null);
+
+  useEffect(() => {
+    const obtenerPatinador = async () => {
+      try {
+        const res = await api.get(`/patinadores/${id}`);
+        setPatinador(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    obtenerPatinador();
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const formData = new FormData();
+    formData.append('primerNombre', form.primerNombre.value);
+    formData.append('segundoNombre', form.segundoNombre.value);
+    formData.append('apellido', form.apellido.value);
+    formData.append('edad', form.edad.value);
+    formData.append('fechaNacimiento', form.fechaNacimiento.value);
+    formData.append('dni', form.dni.value);
+    formData.append('cuil', form.cuil.value);
+    formData.append('direccion', form.direccion.value);
+    formData.append('dniMadre', form.dniMadre.value);
+    formData.append('dniPadre', form.dniPadre.value);
+    formData.append('telefono', form.telefono.value);
+    formData.append('sexo', form.sexo.value);
+    formData.append('nivel', form.nivel.value);
+    formData.append('numeroCorredor', form.numeroCorredor.value);
+    formData.append('categoria', form.categoria.value);
+    if (fotoRostro) formData.append('fotoRostro', fotoRostro);
+    if (foto) formData.append('foto', foto);
+
+    try {
+      await api.put(`/patinadores/${id}`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      });
+      setMensaje('Patinador actualizado correctamente');
+    } catch (err) {
+      console.error(err);
+      setMensaje(
+        err.response?.data?.mensaje || 'Error al actualizar el patinador'
+      );
+    }
+  };
+
+  if (!patinador) {
+    return <div className="container mt-4">Cargando...</div>;
+  }
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Editar Patinador</h1>
+      <form onSubmit={handleSubmit}>
+        <div className="row g-3">
+          <div className="col-md-6">
+            <label className="form-label">Primer Nombre</label>
+            <input
+              type="text"
+              className="form-control"
+              name="primerNombre"
+              defaultValue={patinador.primerNombre}
+              required
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Segundo Nombre</label>
+            <input
+              type="text"
+              className="form-control"
+              name="segundoNombre"
+              defaultValue={patinador.segundoNombre || ''}
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Apellido</label>
+            <input
+              type="text"
+              className="form-control"
+              name="apellido"
+              defaultValue={patinador.apellido}
+              required
+            />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label">Edad</label>
+            <input
+              type="number"
+              className="form-control"
+              name="edad"
+              defaultValue={patinador.edad}
+              required
+            />
+          </div>
+          <div className="col-md-3">
+            <label className="form-label">Fecha de Nacimiento</label>
+            <input
+              type="date"
+              className="form-control"
+              name="fechaNacimiento"
+              defaultValue={patinador.fechaNacimiento?.substring(0, 10)}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">DNI</label>
+            <input
+              type="text"
+              className="form-control"
+              name="dni"
+              defaultValue={patinador.dni}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">CUIL</label>
+            <input
+              type="text"
+              className="form-control"
+              name="cuil"
+              defaultValue={patinador.cuil}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Dirección</label>
+            <input
+              type="text"
+              className="form-control"
+              name="direccion"
+              defaultValue={patinador.direccion}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">DNI Madre</label>
+            <input
+              type="text"
+              className="form-control"
+              name="dniMadre"
+              defaultValue={patinador.dniMadre}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">DNI Padre</label>
+            <input
+              type="text"
+              className="form-control"
+              name="dniPadre"
+              defaultValue={patinador.dniPadre}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Teléfono</label>
+            <input
+              type="text"
+              className="form-control"
+              name="telefono"
+              defaultValue={patinador.telefono}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Sexo</label>
+            <select
+              className="form-select"
+              name="sexo"
+              defaultValue={patinador.sexo}
+              required
+            >
+              <option value="">Seleccione</option>
+              <option value="M">M</option>
+              <option value="F">F</option>
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Nivel</label>
+            <select
+              className="form-select"
+              name="nivel"
+              defaultValue={patinador.nivel}
+              required
+            >
+              <option value="">Seleccione</option>
+              <option value="Escuela">Escuela</option>
+              <option value="Transicion">Transición</option>
+              <option value="Intermedia">Intermedia</option>
+              <option value="Federados">Federados</option>
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Número de Corredor</label>
+            <input
+              type="number"
+              className="form-control"
+              name="numeroCorredor"
+              defaultValue={patinador.numeroCorredor}
+              required
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Categoría</label>
+            <input
+              type="text"
+              className="form-control"
+              name="categoria"
+              defaultValue={patinador.categoria}
+              required
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Foto Rostro</label>
+            <input
+              type="file"
+              className="form-control"
+              accept="image/*"
+              onChange={(e) => setFotoRostro(e.target.files[0])}
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label">Foto Completa</label>
+            <input
+              type="file"
+              className="form-control"
+              accept="image/*"
+              onChange={(e) => setFoto(e.target.files[0])}
+            />
+          </div>
+        </div>
+        <div className="mt-4">
+          <button type="submit" className="btn btn-primary">
+            Guardar
+          </button>
+        </div>
+      </form>
+      {mensaje && <div className="alert alert-info mt-3">{mensaje}</div>}
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import api from '../api.js';
 
 export default function ListaPatinadores() {
@@ -16,23 +17,61 @@ export default function ListaPatinadores() {
     obtenerPatinadores();
   }, []);
 
+  const eliminarPatinador = async (id) => {
+    if (!window.confirm('¿Eliminar patinador?')) return;
+    try {
+      await api.delete(`/patinadores/${id}`);
+      setPatinadores(patinadores.filter((p) => p._id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="container mt-4">
       <h1 className="mb-4">Patinadores</h1>
-      <ul className="list-group">
+      <div className="row">
         {patinadores.map((p) => (
-          <li
-            key={p._id}
-            className="list-group-item d-flex justify-content-between"
-          >
-            <span>
-              {p.primerNombre} {p.segundoNombre ? `${p.segundoNombre} ` : ''}
-              {p.apellido}
-            </span>
-            <span>{p.edad} años</span>
-          </li>
+          <div className="col-md-4 mb-4" key={p._id}>
+            <div className="card h-100">
+              {p.fotoRostro && (
+                <img
+                  src={p.fotoRostro}
+                  className="card-img-top"
+                  alt={`${p.primerNombre} ${p.apellido}`}
+                />
+              )}
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">
+                  {p.primerNombre} {p.apellido}
+                </h5>
+                <p className="card-text">Edad: {p.edad}</p>
+                <p className="card-text">Categoría: {p.categoria}</p>
+                <div className="mt-auto">
+                  <Link
+                    to={`/patinadores/${p._id}`}
+                    className="btn btn-primary me-2"
+                  >
+                    Ver
+                  </Link>
+                  <Link
+                    to={`/patinadores/${p._id}/editar`}
+                    className="btn btn-secondary me-2"
+                  >
+                    Editar
+                  </Link>
+                  <button
+                    onClick={() => eliminarPatinador(p._id)}
+                    className="btn btn-danger"
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 }

--- a/frontend-auth/src/pages/VerPatinador.jsx
+++ b/frontend-auth/src/pages/VerPatinador.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import api from '../api.js';
+
+export default function VerPatinador() {
+  const { id } = useParams();
+  const [patinador, setPatinador] = useState(null);
+
+  useEffect(() => {
+    const fetchPatinador = async () => {
+      try {
+        const res = await api.get(`/patinadores/${id}`);
+        setPatinador(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchPatinador();
+  }, [id]);
+
+  if (!patinador) {
+    return <div className="container mt-4">Cargando...</div>;
+  }
+
+  return (
+    <div className="container mt-4">
+      <h1>
+        {patinador.primerNombre} {patinador.segundoNombre ? `${patinador.segundoNombre} ` : ''}
+        {patinador.apellido}
+      </h1>
+      {patinador.fotoRostro && (
+        <img
+          src={patinador.fotoRostro}
+          alt={`${patinador.primerNombre} ${patinador.apellido}`}
+          style={{ maxWidth: '200px' }}
+          className="img-fluid mb-3"
+        />
+      )}
+      <ul className="list-group mb-3">
+        <li className="list-group-item">Edad: {patinador.edad}</li>
+        <li className="list-group-item">
+          Fecha de Nacimiento: {new Date(patinador.fechaNacimiento).toLocaleDateString()}
+        </li>
+        <li className="list-group-item">DNI: {patinador.dni}</li>
+        <li className="list-group-item">CUIL: {patinador.cuil}</li>
+        <li className="list-group-item">Dirección: {patinador.direccion}</li>
+        <li className="list-group-item">DNI Madre: {patinador.dniMadre}</li>
+        <li className="list-group-item">DNI Padre: {patinador.dniPadre}</li>
+        <li className="list-group-item">Teléfono: {patinador.telefono}</li>
+        <li className="list-group-item">Sexo: {patinador.sexo}</li>
+        <li className="list-group-item">Nivel: {patinador.nivel}</li>
+        <li className="list-group-item">
+          Número de Corredor: {patinador.numeroCorredor}
+        </li>
+        <li className="list-group-item">Categoría: {patinador.categoria}</li>
+      </ul>
+      {patinador.foto && (
+        <div className="mb-3">
+          <img
+            src={patinador.foto}
+            alt={`${patinador.primerNombre} ${patinador.apellido}`}
+            className="img-fluid"
+            style={{ maxWidth: '300px' }}
+          />
+        </div>
+      )}
+      <Link to="/patinadores" className="btn btn-secondary">
+        Volver
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- list skaters as cards including photo, age and category with controls to view, edit or remove
- allow viewing complete skater info and editing existing skaters
- expose backend endpoints to fetch, update and delete individual skaters

## Testing
- `npm test` (frontend-auth) *(fails: Missing script "test")*
- `npm run lint` (frontend-auth)
- `npm test` (backend-auth) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689703836f948320ae55473ac378593c