### PR TITLE
Fix news loading on home page

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -10,14 +10,20 @@ export default function Home() {
   useEffect(() => {
     const cargarDatos = async () => {
       try {
-        const [newsRes, patRes] = await Promise.all([
-          api.get('/news'),
-          api.get('/patinadores/asociados')
-        ]);
+        const newsRes = await api.get('/news');
         setNews(newsRes.data);
-        setPatinadores(patRes.data);
       } catch (err) {
         console.error(err);
+      }
+
+      const token = localStorage.getItem('token');
+      if (token) {
+        try {
+          const patRes = await api.get('/patinadores/asociados');
+          setPatinadores(patRes.data);
+        } catch (err) {
+          console.error(err);
+        }
       }
     };
     cargarDatos();


### PR DESCRIPTION
## Summary
- load news even when not logged in
- skip patinador request without token to avoid failure

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897e23f467483208d8ad471da36add6