### PR TITLE
Handle missing user when fetching associated skaters

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -354,6 +354,9 @@ app.put(
   app.get('/api/patinadores/asociados', protegerRuta, async (req, res) => {
     try {
       const usuario = await User.findById(req.usuario.id).populate('patinadores');
+      if (!usuario) {
+        return res.status(404).json({ mensaje: 'Usuario no encontrado' });
+      }
       res.json(usuario.patinadores || []);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- Avoid server crash when requesting associated skaters by returning 404 if user doesn't exist

## Testing
- `npm test` (backend-auth) *(fails: Missing script)*
- `npm test` (frontend-auth) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6897e468444c83208805654e2ca10a3e