### PR TITLE
Remove patinador association feature

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -321,40 +321,6 @@ app.put(
     }
   });
 
-  // Asociar patinadores a un usuario por DNI de padre o madre
-  app.post('/api/patinadores/asociar', protegerRuta, async (req, res) => {
-    try {
-      const { dni } = req.body;
-      if (!dni) {
-        return res.status(400).json({ mensaje: 'DNI requerido' });
-      }
-
-      const patinadores = await Patinador.find({
-        $or: [{ dniMadre: dni }, { dniPadre: dni }]
-      });
-
-      if (patinadores.length === 0) {
-        return res.status(404).json({ mensaje: 'No se encontraron patinadores' });
-      }
-
-      const userId = req.usuario.id || req.usuario._id;
-      if (!mongoose.Types.ObjectId.isValid(userId)) {
-        return res.status(400).json({ mensaje: 'ID de usuario no válido' });
-      }
-
-      await User.findByIdAndUpdate(
-        userId,
-        { $addToSet: { patinadores: { $each: patinadores.map((p) => p._id) } } },
-        { new: true }
-      );
-
-      res.json(patinadores);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ mensaje: 'Error al asociar patinadores' });
-    }
-  });
-
   // Obtener patinadores asociados a un usuario
   app.get('/api/patinadores/asociados', protegerRuta, async (req, res) => {
     try {

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -4,8 +4,7 @@ import api from '../api.js';
 export default function Home() {
   const [news, setNews] = useState([]);
   const [patinadores, setPatinadores] = useState([]);
-  const [mostrarForm, setMostrarForm] = useState(false);
-  const [dni, setDni] = useState('');
+  
 
   useEffect(() => {
     const cargarDatos = async () => {
@@ -29,45 +28,8 @@ export default function Home() {
     cargarDatos();
   }, []);
 
-  const asociarPatinador = async (e) => {
-    e.preventDefault();
-    try {
-      await api.post('/patinadores/asociar', { dni });
-      const res = await api.get('/patinadores/asociados');
-      setPatinadores(res.data);
-      setDni('');
-      setMostrarForm(false);
-    } catch (err) {
-      console.error(err);
-      alert('No se encontraron patinadores para ese DNI');
-    }
-  };
-
   return (
     <div className="container mt-4">
-      <button
-        className="btn btn-primary mb-3"
-        onClick={() => setMostrarForm(!mostrarForm)}
-      >
-        Asociar Patinador
-      </button>
-      {mostrarForm && (
-        <form onSubmit={asociarPatinador} className="mb-4">
-          <div className="input-group">
-            <input
-              type="text"
-              className="form-control"
-              placeholder="DNI"
-              value={dni}
-              onChange={(e) => setDni(e.target.value)}
-            />
-            <button type="submit" className="btn btn-success">
-              Asociar
-            </button>
-          </div>
-        </form>
-      )}
-
       {patinadores.map((p) => (
         <div className="card mb-3" key={p._id}>
           <div className="row g-0">


### PR DESCRIPTION
## Summary
- remove patinador association form and handler from Home page
- drop backend endpoint for associating patinadores

## Testing
- `npm test` (backend-auth) *(fails: Missing script: "test")*
- `npm test` (frontend-auth) *(fails: Missing script: "test")*
- `npm run lint` (frontend-auth)


------
https://chatgpt.com/codex/tasks/task_e_68989afffca483209e6a8d221e841717