### PR TITLE
Corregir obtención de patinadores asociados en Home

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -334,9 +334,9 @@ app.put(
         return res.status(404).json({ mensaje: 'Usuario no encontrado' });
       }
 
-      const patinadorIds = (usuario.patinadores || []).filter((id) =>
-        mongoose.Types.ObjectId.isValid(id)
-      );
+      const patinadorIds = Array.isArray(usuario.patinadores)
+        ? usuario.patinadores.filter((id) => mongoose.Types.ObjectId.isValid(id))
+        : [];
 
       const patinadores = await Patinador.find({ _id: { $in: patinadorIds } });
 

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -18,7 +18,9 @@ export default function Home() {
       const token = localStorage.getItem('token');
       if (token) {
         try {
-          const patRes = await api.get('/patinadores/asociados');
+          const patRes = await api.get('/patinadores/asociados', {
+            headers: { Authorization: `Bearer ${token}` }
+          });
           setPatinadores(patRes.data);
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
## Summary
- Validar lista de patinadores del usuario antes de consultar en backend
- Enviar token de autenticación al cargar patinadores en la página Home

## Testing
- `npm test` (backend) *(missing script)*
- `npm test` (frontend) *(missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68989d0f31708320aff33615926f46bf