### PR TITLE
Remove patinador association features

### DIFF
--- a/backend-auth/models/User.js
+++ b/backend-auth/models/User.js
@@ -15,8 +15,7 @@ const userSchema = new mongoose.Schema(
     confirmado: { type: Boolean, default: false },
     tokenConfirmacion: { type: String },
     googleId: { type: String }, // por si se loguea con Google
-    foto: { type: String },
-    patinadores: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' }]
+    foto: { type: String }
   },
   { timestamps: true }
 );

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -321,32 +321,6 @@ app.put(
     }
   });
 
-  // Obtener patinadores asociados a un usuario
-  app.get('/api/patinadores/asociados', protegerRuta, async (req, res) => {
-    try {
-      const userId = req.usuario.id || req.usuario._id;
-      if (!mongoose.Types.ObjectId.isValid(userId)) {
-        return res.status(400).json({ mensaje: 'ID de usuario no válido' });
-      }
-
-      const usuario = await User.findById(userId).lean();
-      if (!usuario) {
-        return res.status(404).json({ mensaje: 'Usuario no encontrado' });
-      }
-
-      const patinadorIds = Array.isArray(usuario.patinadores)
-        ? usuario.patinadores.filter((id) => mongoose.Types.ObjectId.isValid(id))
-        : [];
-
-      const patinadores = await Patinador.find({ _id: { $in: patinadorIds } });
-
-      res.json(patinadores);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ mensaje: 'Error al obtener patinadores asociados' });
-    }
-  });
-
 app.get('/api/news', async (req, res) => {
   try {
     const noticias = await News.find()

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -3,61 +3,20 @@ import api from '../api.js';
 
 export default function Home() {
   const [news, setNews] = useState([]);
-  const [patinadores, setPatinadores] = useState([]);
-  
-
   useEffect(() => {
-    const cargarDatos = async () => {
+    const cargarNoticias = async () => {
       try {
         const newsRes = await api.get('/news');
         setNews(newsRes.data);
       } catch (err) {
         console.error(err);
       }
-
-      const token = localStorage.getItem('token');
-      if (token) {
-        try {
-          const patRes = await api.get('/patinadores/asociados', {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          setPatinadores(patRes.data);
-        } catch (err) {
-          console.error(err);
-        }
-      }
     };
-    cargarDatos();
+    cargarNoticias();
   }, []);
 
   return (
     <div className="container mt-4">
-      {patinadores.map((p) => (
-        <div className="card mb-3" key={p._id}>
-          <div className="row g-0">
-            <div className="col-md-4">
-              {p.foto && (
-                <img
-                  src={p.foto}
-                  className="img-fluid rounded-start"
-                  alt={`${p.primerNombre} ${p.apellido}`}
-                />
-              )}
-            </div>
-            <div className="col-md-8">
-              <div className="card-body">
-                <h5 className="card-title">
-                  {p.primerNombre} {p.apellido}
-                </h5>
-                <p className="card-text mb-1">Edad: {p.edad}</p>
-                <p className="card-text mb-1">Categoría: {p.categoria}</p>
-                <p className="card-text">Número de corredor: {p.numeroCorredor}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      ))}
-
       <h1 className="mb-4">Noticias</h1>
       {news.map((n) => (
         <div className="card mb-3" key={n._id}>


### PR DESCRIPTION
## Summary
- remove retrieval and display of associated patinadores from Home page
- drop patinadores field from user model
- delete API route that returned patinadores associated to a user

## Testing
- `npm test` (frontend-auth) *(fails: Missing script)*
- `npm run lint` (frontend-auth)
- `npm test` (backend-auth) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68989ff56e148320a11605d32a3ff6f2