### PR TITLE
Add skater association feature

### DIFF
--- a/backend-auth/models/User.js
+++ b/backend-auth/models/User.js
@@ -15,7 +15,8 @@ const userSchema = new mongoose.Schema(
     confirmado: { type: Boolean, default: false },
     tokenConfirmacion: { type: String },
     googleId: { type: String }, // por si se loguea con Google
-    foto: { type: String }
+    foto: { type: String },
+    patinadores: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' }]
   },
   { timestamps: true }
 );

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -11,6 +11,7 @@ import CrearNoticia from './pages/CrearNoticia';
 import ListaPatinadores from './pages/ListaPatinadores';
 import VerPatinador from './pages/VerPatinador';
 import EditarPatinador from './pages/EditarPatinador';
+import AsociarPatinadores from './pages/AsociarPatinadores';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -35,6 +36,7 @@ function AppRoutes() {
           path="/crear-noticia"
           element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><CrearNoticia /></ProtectedRoute>}
         />
+        <Route path="/asociar-patinadores" element={<ProtectedRoute><AsociarPatinadores /></ProtectedRoute>} />
         <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />
       </Routes>
     </>

--- a/frontend-auth/src/pages/AsociarPatinadores.jsx
+++ b/frontend-auth/src/pages/AsociarPatinadores.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import api from '../api.js';
+
+export default function AsociarPatinadores() {
+  const [dniPadre, setDniPadre] = useState('');
+  const [dniMadre, setDniMadre] = useState('');
+  const [patinadores, setPatinadores] = useState([]);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await api.post('/patinadores/asociar', { dniPadre, dniMadre });
+      setPatinadores(res.data);
+      setError('');
+    } catch (err) {
+      setPatinadores([]);
+      setError(err.response?.data?.mensaje || 'Error al asociar patinadores');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-3">Asociar Patinadores</h1>
+      <form onSubmit={handleSubmit} className="mb-4">
+        <div className="mb-3">
+          <label className="form-label">DNI del Padre</label>
+          <input
+            type="text"
+            className="form-control"
+            value={dniPadre}
+            onChange={(e) => setDniPadre(e.target.value)}
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">DNI de la Madre</label>
+          <input
+            type="text"
+            className="form-control"
+            value={dniMadre}
+            onChange={(e) => setDniMadre(e.target.value)}
+          />
+        </div>
+        <button type="submit" className="btn btn-primary">Asociar</button>
+      </form>
+      {error && <div className="alert alert-danger">{error}</div>}
+      {patinadores.map((p) => (
+        <div className="card mb-3" key={p._id}>
+          <div className="row g-0">
+            {p.foto && (
+              <div className="col-md-4">
+                <img src={p.foto} className="img-fluid rounded-start" alt="foto patinador" />
+              </div>
+            )}
+            <div className="col-md-8">
+              <div className="card-body">
+                <h5 className="card-title">{p.primerNombre} {p.apellido}</h5>
+                <p className="card-text"><strong>Categoría:</strong> {p.categoria}</p>
+                <p className="card-text"><strong>Edad:</strong> {p.edad}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import api from '../api.js';
 
 export default function Home() {
@@ -17,6 +18,11 @@ export default function Home() {
 
   return (
     <div className="container mt-4">
+      <div className="d-flex justify-content-end mb-3">
+        <Link to="/asociar-patinadores" className="btn btn-primary">
+          Asociar Patinadores
+        </Link>
+      </div>
       <h1 className="mb-4">Noticias</h1>
       {news.map((n) => (
         <div className="card mb-3" key={n._id}>


### PR DESCRIPTION
## Summary
- store associated skaters on user model
- backend endpoint to link skaters by parent DNI
- new page and routing to associate and display skaters
- home button linking to association page

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint`
- `npm test` (backend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689924560b14832097fb0e59f056fe04