### PR TITLE
Show associated skater cards on home page

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -149,7 +149,9 @@ app.post('/api/auth/login', async (req, res) => {
 
 app.get('/api/protegido/usuario', protegerRuta, async (req, res) => {
   try {
-    const usuario = await User.findById(req.usuario.id).select('-password');
+    const usuario = await User.findById(req.usuario.id)
+      .select('-password')
+      .populate('patinadores');
     res.json({ usuario });
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al obtener el usuario' });

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -4,6 +4,8 @@ import api from '../api.js';
 
 export default function Home() {
   const [news, setNews] = useState([]);
+  const [patinadores, setPatinadores] = useState([]);
+
   useEffect(() => {
     const cargarNoticias = async () => {
       try {
@@ -13,16 +15,62 @@ export default function Home() {
         console.error(err);
       }
     };
+
+    const cargarPatinadores = async () => {
+      try {
+        const userRes = await api.get('/protegido/usuario');
+        setPatinadores(userRes.data.usuario.patinadores || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
     cargarNoticias();
+    if (localStorage.getItem('token')) {
+      cargarPatinadores();
+    }
   }, []);
+
+  const tienePatinadores = patinadores.length > 0;
 
   return (
     <div className="container mt-4">
-      <div className="d-flex justify-content-end mb-3">
-        <Link to="/asociar-patinadores" className="btn btn-primary">
-          Asociar Patinadores
-        </Link>
-      </div>
+      {localStorage.getItem('token') && !tienePatinadores && (
+        <div className="d-flex justify-content-end mb-3">
+          <Link to="/asociar-patinadores" className="btn btn-primary">
+            Asociar Patinadores
+          </Link>
+        </div>
+      )}
+      {localStorage.getItem('token') && tienePatinadores && (
+        <>
+          <h2 className="mb-4">Patinadores Asociados</h2>
+          {patinadores.map((p) => (
+            <div className="card mb-3" key={p._id}>
+              <div className="row g-0">
+                {p.foto && (
+                  <div className="col-md-4">
+                    <img src={p.foto} className="img-fluid rounded-start" alt="foto patinador" />
+                  </div>
+                )}
+                <div className="col-md-8">
+                  <div className="card-body">
+                    <h5 className="card-title">
+                      {p.primerNombre} {p.apellido}
+                    </h5>
+                    <p className="card-text">
+                      <strong>Categoría:</strong> {p.categoria}
+                    </p>
+                    <p className="card-text">
+                      <strong>Edad:</strong> {p.edad}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </>
+      )}
       <h1 className="mb-4">Noticias</h1>
       {news.map((n) => (
         <div className="card mb-3" key={n._id}>


### PR DESCRIPTION
## Summary
- Populate associated skaters when retrieving authenticated user
- Display associated skater cards on home page and hide link once linked

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint`
- `npm test` (backend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899a5a3705c8320b6826a9b5088f15a