### PR TITLE
Add notifications system and bell icon

### DIFF
--- a/backend-auth/models/Notification.js
+++ b/backend-auth/models/Notification.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const notificationSchema = new mongoose.Schema(
+  {
+    destinatario: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    mensaje: { type: String, required: true },
+    leido: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+const Notification = mongoose.model('Notification', notificationSchema);
+export default Notification;

--- a/frontend-auth/index.html
+++ b/frontend-auth/index.html
@@ -9,6 +9,10 @@
       rel="stylesheet"
       crossorigin="anonymous"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+    />
     <title>Vite + React</title>
   </head>
   <body>

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -12,6 +12,8 @@ import ListaPatinadores from './pages/ListaPatinadores';
 import VerPatinador from './pages/VerPatinador';
 import EditarPatinador from './pages/EditarPatinador';
 import AsociarPatinadores from './pages/AsociarPatinadores';
+import Notificaciones from './pages/Notificaciones';
+import CrearNotificacion from './pages/CrearNotificacion';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -36,8 +38,13 @@ function AppRoutes() {
           path="/crear-noticia"
           element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><CrearNoticia /></ProtectedRoute>}
         />
+        <Route
+          path="/crear-notificacion"
+          element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><CrearNotificacion /></ProtectedRoute>}
+        />
         <Route path="/asociar-patinadores" element={<ProtectedRoute><AsociarPatinadores /></ProtectedRoute>} />
         <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />
+        <Route path="/notificaciones" element={<ProtectedRoute><Notificaciones /></ProtectedRoute>} />
       </Routes>
     </>
   );

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../api.js';
 import LogoutButton from './LogoutButton';
@@ -9,6 +9,20 @@ export default function Navbar() {
   const rol = localStorage.getItem('rol');
   const foto = localStorage.getItem('foto');
   const isLoggedIn = localStorage.getItem('token');
+  const [unread, setUnread] = useState(0);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get('/notifications');
+        const count = res.data.filter((n) => !n.leido).length;
+        setUnread(count);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    if (isLoggedIn) cargar();
+  }, [isLoggedIn]);
 
   const handleNavigate = (path) => navigate(path);
 
@@ -45,7 +59,10 @@ export default function Navbar() {
         { label: 'Patinadores', path: '/patinadores' },
         { label: 'Cargar Patinador', path: '/cargar-patinador' },
         ...(rol === 'Delegado' || rol === 'Tecnico'
-          ? [{ label: 'Crear Noticia', path: '/crear-noticia' }]
+          ? [
+              { label: 'Crear Noticia', path: '/crear-noticia' },
+              { label: 'Crear Notificacion', path: '/crear-notificacion' }
+            ]
           : [])
       ]
     : [];
@@ -93,6 +110,18 @@ export default function Navbar() {
           </ul>
           {isLoggedIn && (
             <div className="d-flex align-items-center gap-2 ms-auto">
+              <div className="position-relative me-2">
+                <i
+                  className="bi bi-bell"
+                  style={{ fontSize: '1.5rem', color: unread > 0 ? 'red' : 'gray', cursor: 'pointer' }}
+                  onClick={() => handleNavigate('/notificaciones')}
+                ></i>
+                {unread > 0 && (
+                  <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                    {unread}
+                  </span>
+                )}
+              </div>
               <div className="position-relative">
                 <img
                   src={foto || '/default-user.png'}

--- a/frontend-auth/src/pages/CrearNotificacion.jsx
+++ b/frontend-auth/src/pages/CrearNotificacion.jsx
@@ -1,0 +1,29 @@
+import { useNavigate } from 'react-router-dom';
+import api from '../api.js';
+
+export default function CrearNotificacion() {
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/notifications', { mensaje: e.target.mensaje.value });
+      navigate('/home');
+    } catch (err) {
+      alert(err.response?.data?.mensaje || 'Error al crear la notificación');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Crear Notificación</h1>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Mensaje</label>
+          <textarea name="mensaje" className="form-control" rows="3" required></textarea>
+        </div>
+        <button type="submit" className="btn btn-primary">Enviar</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import api from '../api.js';
+
+export default function Notificaciones() {
+  const [notificaciones, setNotificaciones] = useState([]);
+
+  const cargar = async () => {
+    try {
+      const res = await api.get('/notifications');
+      setNotificaciones(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    cargar();
+  }, []);
+
+  const marcarLeida = async (id) => {
+    try {
+      await api.put(`/notifications/${id}/read`);
+      cargar();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (notificaciones.length === 0) {
+    return (
+      <div className="container mt-4">
+        <h1 className="mb-4">Notificaciones</h1>
+        <p>No hay notificaciones.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Notificaciones</h1>
+      <ul className="list-group">
+        {notificaciones.map((n) => (
+          <li
+            key={n._id}
+            className={`list-group-item d-flex justify-content-between align-items-center ${n.leido ? '' : 'list-group-item-warning'}`}
+          >
+            <span>{n.mensaje}</span>
+            {!n.leido && (
+              <button className="btn btn-sm btn-primary" onClick={() => marcarLeida(n._id)}>
+                Marcar como leída
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add MongoDB Notification model and helper to broadcast notifications
- Create backend routes for creating, listing, and reading notifications, and auto-create on news
- Show notifications in frontend with bell icon, creation page, and listing page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6899a97b6a08832089e65ff12d263f76