### PR TITLE
Restrict menu items to technical and delegate roles

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -30,10 +30,22 @@ function AppRoutes() {
         <Route path="/home" element={<Home />} />
         <Route path="/google-success" element={<GoogleSuccess />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
-        <Route path="/cargar-patinador" element={<ProtectedRoute><CargarPatinador /></ProtectedRoute>} />
-        <Route path="/patinadores" element={<ProtectedRoute><ListaPatinadores /></ProtectedRoute>} />
-        <Route path="/patinadores/:id" element={<ProtectedRoute><VerPatinador /></ProtectedRoute>} />
-        <Route path="/patinadores/:id/editar" element={<ProtectedRoute><EditarPatinador /></ProtectedRoute>} />
+        <Route
+          path="/cargar-patinador"
+          element={<ProtectedRoute roles={['Delegado']}><CargarPatinador /></ProtectedRoute>}
+        />
+        <Route
+          path="/patinadores"
+          element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><ListaPatinadores /></ProtectedRoute>}
+        />
+        <Route
+          path="/patinadores/:id"
+          element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><VerPatinador /></ProtectedRoute>}
+        />
+        <Route
+          path="/patinadores/:id/editar"
+          element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><EditarPatinador /></ProtectedRoute>}
+        />
         <Route
           path="/crear-noticia"
           element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><CrearNoticia /></ProtectedRoute>}

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -65,8 +65,12 @@ export default function Navbar() {
   const navItems = isLoggedIn
     ? [
         { label: 'Inicio', path: '/home' },
-        { label: 'Patinadores', path: '/patinadores' },
-        { label: 'Cargar Patinador', path: '/cargar-patinador' },
+        ...(rol === 'Delegado' || rol === 'Tecnico'
+          ? [{ label: 'Patinadores', path: '/patinadores' }]
+          : []),
+        ...(rol === 'Delegado'
+          ? [{ label: 'Cargar Patinador', path: '/cargar-patinador' }]
+          : []),
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [
               { label: 'Crear Noticia', path: '/crear-noticia' },


### PR DESCRIPTION
## Summary
- Show "Patinadores" and creation menus only for Delegado/Tecnico roles
- Allow only Delegados to access "Cargar Patinador"
- Secure patinador-related routes with role-based guards

## Testing
- `npm test` *(frontend, backend: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aabd7c84083209dfdec5665a31967