### PR TITLE
feat: add tournaments and competitions section

### DIFF
--- a/backend-auth/models/Competencia.js
+++ b/backend-auth/models/Competencia.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const competenciaSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true },
+    torneo: { type: mongoose.Schema.Types.ObjectId, ref: 'Torneo', required: true },
+    fecha: { type: Date, required: true },
+    listaBuenaFe: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' }]
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Competencia', competenciaSchema);

--- a/backend-auth/models/Notification.js
+++ b/backend-auth/models/Notification.js
@@ -4,7 +4,13 @@ const notificationSchema = new mongoose.Schema(
   {
     destinatario: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
     mensaje: { type: String, required: true },
-    leido: { type: Boolean, default: false }
+    leido: { type: Boolean, default: false },
+    competencia: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia' },
+    estadoRespuesta: {
+      type: String,
+      enum: ['Pendiente', 'Participo', 'No Participo'],
+      default: 'Pendiente'
+    }
   },
   { timestamps: true }
 );

--- a/backend-auth/models/Torneo.js
+++ b/backend-auth/models/Torneo.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const torneoSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true },
+    fechaInicio: { type: Date, required: true },
+    fechaFin: { type: Date, required: true }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Torneo', torneoSchema);

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -14,6 +14,7 @@ import EditarPatinador from './pages/EditarPatinador';
 import AsociarPatinadores from './pages/AsociarPatinadores';
 import Notificaciones from './pages/Notificaciones';
 import CrearNotificacion from './pages/CrearNotificacion';
+import Torneos from './pages/Torneos';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -57,6 +58,7 @@ function AppRoutes() {
         <Route path="/asociar-patinadores" element={<ProtectedRoute><AsociarPatinadores /></ProtectedRoute>} />
         <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />
         <Route path="/notificaciones" element={<ProtectedRoute><Notificaciones /></ProtectedRoute>} />
+        <Route path="/torneos" element={<ProtectedRoute><Torneos /></ProtectedRoute>} />
       </Routes>
     </>
   );

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -65,6 +65,7 @@ export default function Navbar() {
   const navItems = isLoggedIn
     ? [
         { label: 'Inicio', path: '/home' },
+        { label: 'Torneos', path: '/torneos' },
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [
               {

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -29,6 +29,22 @@ export default function Notificaciones() {
     }
   };
 
+  const responder = async (competenciaId, notifId, participa) => {
+    try {
+      await api.post(`/competitions/${competenciaId}/responder`, { participa });
+      setNotificaciones((prev) =>
+        prev.map((n) =>
+          n._id === notifId
+            ? { ...n, estadoRespuesta: participa ? 'Participo' : 'No Participo', leido: true }
+            : n
+        )
+      );
+      window.dispatchEvent(new Event('notificationsUpdated'));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   if (notificaciones.length === 0) {
     return (
       <div className="container mt-4">
@@ -43,13 +59,36 @@ export default function Notificaciones() {
       <h1 className="mb-4">Notificaciones</h1>
       <ul className="list-group">
         {notificaciones.map((n) => (
-          <li
-            key={n._id}
-            className={`list-group-item d-flex justify-content-between align-items-center ${n.leido ? '' : 'list-group-item-warning'}`}
-            onClick={() => !n.leido && marcarLeida(n._id)}
-            style={{ cursor: n.leido ? 'default' : 'pointer' }}
-          >
-            <span style={{ fontWeight: n.leido ? 'normal' : 'bold' }}>{n.mensaje}</span>
+          <li key={n._id} className={`list-group-item ${n.leido ? '' : 'list-group-item-warning'}`}>
+            <div className="d-flex justify-content-between align-items-center">
+              <span style={{ fontWeight: n.leido ? 'normal' : 'bold' }}>{n.mensaje}</span>
+              {n.competencia && n.estadoRespuesta !== 'Pendiente' && (
+                <span className="badge bg-secondary">{n.estadoRespuesta}</span>
+              )}
+            </div>
+            {n.competencia && n.estadoRespuesta === 'Pendiente' && (
+              <div className="mt-2">
+                <button
+                  className="btn btn-sm btn-success me-2"
+                  onClick={() => responder(n.competencia, n._id, true)}
+                >
+                  Participo
+                </button>
+                <button
+                  className="btn btn-sm btn-danger"
+                  onClick={() => responder(n.competencia, n._id, false)}
+                >
+                  No Participo
+                </button>
+              </div>
+            )}
+            {!n.competencia && !n.leido && (
+              <div className="mt-2">
+                <button className="btn btn-sm btn-primary" onClick={() => marcarLeida(n._id)}>
+                  Marcar como leída
+                </button>
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import api from '../api.js';
+
+export default function Torneos() {
+  const [torneos, setTorneos] = useState([]);
+  const rol = localStorage.getItem('rol');
+
+  const cargar = async () => {
+    try {
+      const res = await api.get('/tournaments');
+      const data = await Promise.all(
+        res.data.map(async (t) => {
+          const comps = await api.get(`/tournaments/${t._id}/competitions`);
+          return { ...t, competencias: comps.data };
+        })
+      );
+      setTorneos(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    cargar();
+  }, []);
+
+  const crearTorneo = async (e) => {
+    e.preventDefault();
+    const { nombre, fechaInicio, fechaFin } = e.target;
+    try {
+      await api.post('/tournaments', {
+        nombre: nombre.value,
+        fechaInicio: fechaInicio.value,
+        fechaFin: fechaFin.value
+      });
+      e.target.reset();
+      cargar();
+    } catch (err) {
+      alert(err.response?.data?.mensaje || 'Error al crear torneo');
+    }
+  };
+
+  const crearCompetencia = async (e, torneoId) => {
+    e.preventDefault();
+    const { nombre, fecha } = e.target;
+    try {
+      await api.post(`/tournaments/${torneoId}/competitions`, {
+        nombre: nombre.value,
+        fecha: fecha.value
+      });
+      e.target.reset();
+      cargar();
+    } catch (err) {
+      alert(err.response?.data?.mensaje || 'Error al crear competencia');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Torneos</h1>
+      {rol === 'Delegado' && (
+        <form className="mb-4" onSubmit={crearTorneo}>
+          <div className="row g-2">
+            <div className="col-md-4">
+              <input type="text" name="nombre" className="form-control" placeholder="Nombre" required />
+            </div>
+            <div className="col-md-3">
+              <input type="date" name="fechaInicio" className="form-control" required />
+            </div>
+            <div className="col-md-3">
+              <input type="date" name="fechaFin" className="form-control" required />
+            </div>
+            <div className="col-md-2">
+              <button type="submit" className="btn btn-primary w-100">
+                Crear Torneo
+              </button>
+            </div>
+          </div>
+        </form>
+      )}
+      {torneos.map((t) => (
+        <div key={t._id} className="card mb-3">
+          <div className="card-body">
+            <h5 className="card-title">{t.nombre}</h5>
+            <p className="card-text">
+              {new Date(t.fechaInicio).toLocaleDateString()} - {new Date(t.fechaFin).toLocaleDateString()}
+            </p>
+            <ul>
+              {t.competencias.map((c) => (
+                <li key={c._id}>
+                  {c.nombre} - {new Date(c.fecha).toLocaleDateString()}
+                  {rol === 'Delegado' && ` (Lista Buena Fe: ${c.listaBuenaFe?.length || 0})`}
+                </li>
+              ))}
+            </ul>
+            {rol === 'Delegado' && (
+              <form className="row g-2" onSubmit={(e) => crearCompetencia(e, t._id)}>
+                <div className="col-md-5">
+                  <input
+                    type="text"
+                    name="nombre"
+                    className="form-control"
+                    placeholder="Nombre competencia"
+                    required
+                  />
+                </div>
+                <div className="col-md-4">
+                  <input type="date" name="fecha" className="form-control" required />
+                </div>
+                <div className="col-md-3">
+                  <button type="submit" className="btn btn-success w-100">
+                    Agregar
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add tournament and competition models with good faith list
- notify users when a competition is created and capture participation
- build Torneos UI, navigation and interactive notifications

## Testing
- `npm test` (backend-auth) *(fails: Missing script: "test")*
- `npm test` (frontend-auth) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689afc002eb883208e72be411900ca9a