### PR TITLE
Mostrar lista de buena fe y resultados por competencia

### DIFF
--- a/backend-auth/models/Resultado.js
+++ b/backend-auth/models/Resultado.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const resultadoSchema = new mongoose.Schema(
+  {
+    competencia: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia', required: true },
+    nombre: { type: String, required: true },
+    club: { type: String, required: true },
+    tiempo: { type: String },
+    posicion: { type: Number }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Resultado', resultadoSchema);

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -15,6 +15,7 @@ import News from './models/News.js';
 import Notification from './models/Notification.js';
 import Torneo from './models/Torneo.js';
 import Competencia from './models/Competencia.js';
+import Resultado from './models/Resultado.js';
 
 // Cargar variables de entorno desde .env si está presente
 const envPath = path.resolve('.env');
@@ -553,6 +554,43 @@ app.get(
     } catch (err) {
       console.error(err);
       res.status(500).json({ mensaje: 'Error al obtener lista' });
+    }
+  }
+);
+
+app.get('/api/competitions/:id/resultados', protegerRuta, async (req, res) => {
+  try {
+    const resultados = await Resultado.find({ competencia: req.params.id }).sort({ posicion: 1 });
+    res.json(resultados);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al obtener resultados' });
+  }
+});
+
+app.post(
+  '/api/competitions/:id/resultados',
+  protegerRuta,
+  permitirRol('Delegado'),
+  async (req, res) => {
+    const { nombre, club, tiempo, posicion } = req.body;
+    if (!nombre || !club) {
+      return res.status(400).json({ mensaje: 'Faltan datos' });
+    }
+    try {
+      const comp = await Competencia.findById(req.params.id);
+      if (!comp) return res.status(404).json({ mensaje: 'Competencia no encontrada' });
+      const resultado = await Resultado.create({
+        competencia: comp._id,
+        nombre,
+        club,
+        tiempo,
+        posicion
+      });
+      res.status(201).json(resultado);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ mensaje: 'Error al cargar resultado' });
     }
   }
 );

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -3,6 +3,7 @@ import api from '../api.js';
 
 export default function Torneos() {
   const [torneos, setTorneos] = useState([]);
+  const [detalles, setDetalles] = useState({});
   const rol = localStorage.getItem('rol');
 
   const cargar = async () => {
@@ -37,6 +38,57 @@ export default function Torneos() {
       cargar();
     } catch (err) {
       alert(err.response?.data?.mensaje || 'Error al crear torneo');
+    }
+  };
+
+  const toggleCompetencia = async (compId) => {
+    const detalle = detalles[compId];
+    if (detalle) {
+      setDetalles((prev) => ({
+        ...prev,
+        [compId]: { ...detalle, abierta: !detalle.abierta }
+      }));
+      return;
+    }
+    try {
+      const peticiones = [api.get(`/competitions/${compId}/resultados`)];
+      if (rol === 'Delegado') {
+        peticiones.unshift(api.get(`/competitions/${compId}/lista-buena-fe`));
+      }
+      const respuestas = await Promise.all(peticiones);
+      const resultados = respuestas[rol === 'Delegado' ? 1 : 0].data;
+      const lista = rol === 'Delegado' ? respuestas[0].data : [];
+      setDetalles((prev) => ({
+        ...prev,
+        [compId]: {
+          abierta: true,
+          lista,
+          resultados
+        }
+      }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const agregarResultado = async (e, compId) => {
+    e.preventDefault();
+    const { nombre, club, tiempo, posicion } = e.target;
+    try {
+      await api.post(`/competitions/${compId}/resultados`, {
+        nombre: nombre.value,
+        club: club.value,
+        tiempo: tiempo.value,
+        posicion: posicion.value
+      });
+      e.target.reset();
+      const resultados = await api.get(`/competitions/${compId}/resultados`);
+      setDetalles((prev) => ({
+        ...prev,
+        [compId]: { ...prev[compId], resultados: resultados.data }
+      }));
+    } catch (err) {
+      alert(err.response?.data?.mensaje || 'Error al cargar resultado');
     }
   };
 
@@ -87,9 +139,83 @@ export default function Torneos() {
             </p>
             <ul>
               {t.competencias.map((c) => (
-                <li key={c._id}>
-                  {c.nombre} - {new Date(c.fecha).toLocaleDateString()}
+                <li key={c._id} className="mb-2">
+                  <button
+                    type="button"
+                    className="btn btn-link p-0"
+                    onClick={() => toggleCompetencia(c._id)}
+                  >
+                    {c.nombre} - {new Date(c.fecha).toLocaleDateString()}
+                  </button>
                   {rol === 'Delegado' && ` (Lista Buena Fe: ${c.listaBuenaFe?.length || 0})`}
+                  {detalles[c._id]?.abierta && (
+                    <div className="mt-2">
+                      {rol === 'Delegado' && (
+                        <>
+                          <h6>Lista Buena Fe</h6>
+                          <ul>
+                            {(detalles[c._id].lista || []).map((p) => (
+                              <li key={p._id}>
+                                {p.primerNombre} {p.apellido}
+                              </li>
+                            ))}
+                          </ul>
+                        </>
+                      )}
+                      <h6>Resultados</h6>
+                      <ul>
+                        {(detalles[c._id].resultados || []).map((r) => (
+                          <li key={r._id}>
+                            {r.posicion ? `${r.posicion}. ` : ''}
+                            {r.nombre} ({r.club}) {r.tiempo}
+                          </li>
+                        ))}
+                      </ul>
+                      {rol === 'Delegado' && (
+                        <form className="row g-2" onSubmit={(e) => agregarResultado(e, c._id)}>
+                          <div className="col-md-3">
+                            <input
+                              type="text"
+                              name="nombre"
+                              className="form-control"
+                              placeholder="Nombre"
+                              required
+                            />
+                          </div>
+                          <div className="col-md-3">
+                            <input
+                              type="text"
+                              name="club"
+                              className="form-control"
+                              placeholder="Club"
+                              required
+                            />
+                          </div>
+                          <div className="col-md-3">
+                            <input
+                              type="text"
+                              name="tiempo"
+                              className="form-control"
+                              placeholder="Tiempo"
+                            />
+                          </div>
+                          <div className="col-md-2">
+                            <input
+                              type="number"
+                              name="posicion"
+                              className="form-control"
+                              placeholder="Posición"
+                            />
+                          </div>
+                          <div className="col-md-1">
+                            <button type="submit" className="btn btn-primary w-100">
+                              +
+                            </button>
+                          </div>
+                        </form>
+                      )}
+                    </div>
+                  )}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Resumen
- Agrega modelo Resultado para almacenar tiempos y posiciones por competencia.
- Expone endpoints para registrar y consultar resultados de cada competencia.
- Permite desplegar la lista de buena fe y cargar resultados desde la interfaz de torneos.

## Testing
- `npm test` *(backend-auth)*
- `npm test` *(frontend-auth)*
- `npm run lint` *(frontend-auth)*

------
https://chatgpt.com/codex/tasks/task_e_689b8cf8e2c483209246cce7576781e1