### PR TITLE
Ensure uploads directory exists before saving files

### DIFF
--- a/backend-auth/utils/multer.js
+++ b/backend-auth/utils/multer.js
@@ -1,9 +1,16 @@
 import multer from 'multer';
 import path from 'path';
+import fs from 'fs';
+
+// Ensure the uploads directory exists so Multer can save files without errors.
+const uploadDir = path.resolve('uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
 
 const storage = multer.diskStorage({
   destination(req, file, cb) {
-    cb(null, 'uploads/');
+    cb(null, uploadDir);
   },
   filename(req, file, cb) {
     const ext = path.extname(file.originalname);


### PR DESCRIPTION
### Summary
- create uploads directory automatically for Multer to avoid ENOENT errors when uploading competition result PDFs

### Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b98e0e4d08320b4950702f240fff5