### PR TITLE
feat: enable category-based result entry

### DIFF
--- a/backend-auth/models/Resultado.js
+++ b/backend-auth/models/Resultado.js
@@ -5,10 +5,11 @@ const resultadoSchema = new mongoose.Schema(
     competencia: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia', required: true },
     nombre: { type: String, required: true },
     club: { type: String, required: true },
-    tiempo: { type: String },
-    posicion: { type: Number },
+    numero: { type: Number, required: true },
+    puntos: { type: Number, required: true },
     categoria: { type: String },
-    total: { type: Number }
+    tiempo: { type: String },
+    posicion: { type: Number }
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- store runner number and points in competition results
- expose external skaters by category and require number/points when submitting results
- allow delegates to select category and auto-fill skater data when recording results

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm test`
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c748b618083208054bc8394696c50