### PR TITLE
Store external skaters and update local club label

### DIFF
--- a/backend-auth/models/PatinadorExterno.js
+++ b/backend-auth/models/PatinadorExterno.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+
+const patinadorExternoSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true },
+    club: { type: String, required: true },
+    numero: { type: Number },
+    categoria: { type: String, required: true }
+  },
+  { timestamps: true }
+);
+
+const PatinadorExterno = mongoose.model(
+  'PatinadorExterno',
+  patinadorExternoSchema,
+  'patinadorexternos'
+);
+
+export default PatinadorExterno;

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -4,7 +4,7 @@ import api from '../api.js';
 export default function Torneos() {
   const [torneos, setTorneos] = useState([]);
   const [detalles, setDetalles] = useState({});
-  const CLUB_LOCAL = 'Club Local';
+  const CLUB_LOCAL = 'General Rodríguez';
   const rol = localStorage.getItem('rol');
 
   const cargar = async () => {


### PR DESCRIPTION
## Summary
- add `PatinadorExterno` model to persist skaters from other clubs
- save external skaters when loading results and fetch them for dropdowns
- rename local club references to "General Rodríguez"

## Testing
- `npm test` *(backend)*
- `npm test` *(frontend)*
- `npm run lint` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_689c77dde41c8320ad4b2f73272a79de