### PR TITLE
Fix backend URL handling for API and uploads

### DIFF
--- a/backend-auth/routes/protegidas.js
+++ b/backend-auth/routes/protegidas.js
@@ -4,6 +4,9 @@ const { protegerRuta, permitirRol } = require('../middlewares/authMiddleware');
 const User = require('../models/User');
 const upload = require('../utils/multer');
 
+// Base URL of the backend, used when returning file paths.
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5000';
+
 
 router.get('/usuario', protegerRuta, async (req, res) => {
   const usuario = await User.findById(req.usuario.id).select('-password');
@@ -24,7 +27,7 @@ router.get('/usuarios', protegerRuta, permitirRol('admin'), async (req, res) => 
 router.post('/foto-perfil', protegerRuta, upload.single('foto'), async (req, res) => {
   try {
     const user = await User.findById(req.usuario.id);
-    user.foto = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`;
+    user.foto = `${BACKEND_URL}/uploads/${req.file.filename}`;
     await user.save();
     res.json({ mensaje: 'Foto actualizada', foto: user.foto });
   } catch (err) {

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -188,7 +188,9 @@ app.post(
   async (req, res) => {
     try {
       const user = await User.findById(req.usuario.id);
-      user.foto = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`;
+      // Use the configured backend URL when returning the uploaded image so the
+      // path is valid even when requests are proxied through another host.
+      user.foto = `${BACKEND_URL}/uploads/${req.file.filename}`;
       await user.save();
       res.json({ mensaje: 'Foto actualizada', foto: user.foto });
     } catch (err) {
@@ -245,10 +247,10 @@ app.post(
         numeroCorredor,
         categoria,
         fotoRostro: fotoRostroFile
-          ? `${req.protocol}://${req.get('host')}/uploads/${fotoRostroFile.filename}`
+          ? `${BACKEND_URL}/uploads/${fotoRostroFile.filename}`
           : undefined,
         foto: fotoFile
-          ? `${req.protocol}://${req.get('host')}/uploads/${fotoFile.filename}`
+          ? `${BACKEND_URL}/uploads/${fotoFile.filename}`
           : undefined
       });
 
@@ -309,10 +311,10 @@ app.put(
       const fotoFile = req.files?.foto?.[0];
 
       if (fotoRostroFile) {
-        actualizacion.fotoRostro = `${req.protocol}://${req.get('host')}/uploads/${fotoRostroFile.filename}`;
+        actualizacion.fotoRostro = `${BACKEND_URL}/uploads/${fotoRostroFile.filename}`;
       }
       if (fotoFile) {
-        actualizacion.foto = `${req.protocol}://${req.get('host')}/uploads/${fotoFile.filename}`;
+        actualizacion.foto = `${BACKEND_URL}/uploads/${fotoFile.filename}`;
       }
 
       const patinadorActualizado = await Patinador.findByIdAndUpdate(
@@ -404,7 +406,7 @@ app.post(
     try {
       const { titulo, contenido } = req.body;
       const imagen = req.file
-        ? `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+        ? `${BACKEND_URL}/uploads/${req.file.filename}`
         : undefined;
       const noticia = await News.create({
         titulo,

--- a/frontend-auth/src/api.js
+++ b/frontend-auth/src/api.js
@@ -1,8 +1,12 @@
 import axios from 'axios';
 
 // Axios instance that automatically attaches the JWT token from localStorage
+// Use the API URL from environment variables when available. If it is not
+// provided, fall back to a relative `/api` path so the frontend can work
+// regardless of where the backend is hosted. During development the Vite
+// proxy will redirect these calls to the backend server.
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api'
+  baseURL: import.meta.env.VITE_API_URL || '/api'
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend-auth/src/components/LoginForm.jsx
+++ b/frontend-auth/src/components/LoginForm.jsx
@@ -27,9 +27,11 @@ export default function LoginForm() {
     }
   };
 
+  // Redirect the user to the backend's Google auth endpoint. Using the base
+  // URL from our Axios instance avoids hard-coding `localhost` and keeps the
+  // frontend portable across environments.
   const handleGoogleLogin = () => {
-
-    window.location.href = 'http://localhost:5000/api/auth/google';
+    window.location.href = `${api.defaults.baseURL}/auth/google`;
   };
 
   return (

--- a/frontend-auth/vite.config.js
+++ b/frontend-auth/vite.config.js
@@ -1,7 +1,22 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  // Proxy API requests during development so the frontend can use a relative
+  // `/api` path regardless of where the backend runs. This also proxies
+  // requests for uploaded files.
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      },
+      '/uploads': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Use configurable base URL for Axios and Google login
- Proxy `/api` and `/uploads` through Vite dev server
- Build upload URLs with `BACKEND_URL` to avoid hardcoded hosts

## Testing
- `npm test` *(backend)* (fails: Missing script "test")
- `npm run lint` *(backend)* (fails: Missing script "lint")
- `npm test` *(frontend)* (fails: Missing script "test")
- `npm run lint` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_689c96c915348320887f9e6d264e3d51