### PR TITLE
Handle empty roster when generating buena fe Excel

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -663,8 +663,8 @@ app.get(
       d8.font = { name: 'Arial', size: 10 };
       d8.alignment = { horizontal: 'center', vertical: 'middle' };
 
-      const lista = comp.listaBuenaFe;
-      const getGrupo = (cat) => {
+      const lista = Array.isArray(comp.listaBuenaFe) ? comp.listaBuenaFe : [];
+      const getGrupo = (cat = '') => {
         const l = cat.trim().slice(-1).toUpperCase();
         if (l === 'F') return 'F';
         if (l === 'E') return 'E';


### PR DESCRIPTION
## Summary
- Avoid crashing when `listaBuenaFe` is undefined by defaulting to an empty array
- Guard `getGrupo` helper with default parameter to handle missing categories

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689cb15e86d883208de2e632cdb7ef03