### PR TITLE
fix: handle null categories in Excel export

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -664,7 +664,8 @@ app.get(
       d8.alignment = { horizontal: 'center', vertical: 'middle' };
 
       const lista = Array.isArray(comp.listaBuenaFe) ? comp.listaBuenaFe : [];
-      const getGrupo = (cat = '') => {
+      const getGrupo = (cat) => {
+        if (!cat || typeof cat !== 'string') return '';
         const l = cat.trim().slice(-1).toUpperCase();
         if (l === 'F') return 'F';
         if (l === 'E') return 'E';


### PR DESCRIPTION
## Summary
- avoid crashes when category is null during lista-buena-fe Excel generation

## Testing
- `npm test` (backend-auth) *(fails: Missing script "test")*
- `npm test` (frontend-auth) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d196cb8e08320bf4a540bac43b954