### PR TITLE
feat: add default mongodb uri

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -32,8 +32,13 @@ if (fs.existsSync(envPath)) {
   });
 }
 
+// Define la URI de MongoDB con un valor predeterminado para evitar errores
+// cuando no se proporciona la variable de entorno correspondiente.
+const MONGODB_URI =
+  process.env.MONGODB_URI || 'mongodb://localhost:27017/backend-auth';
+
 mongoose
-  .connect(process.env.MONGODB_URI)
+  .connect(MONGODB_URI)
   .then(() => console.log('MongoDB conectado'))
   .catch((err) => console.error('Error conectando a MongoDB:', err.message));
 


### PR DESCRIPTION
## Summary
- prevent crashes on missing MongoDB connection string by using a default URI

## Testing
- `node backend-auth/server.js`


------
https://chatgpt.com/codex/tasks/task_e_689d1c7667c0832090c04978a53bf371