### PR TITLE
Handle login errors gracefully

### DIFF
--- a/backend-auth/controllers/authController.js
+++ b/backend-auth/controllers/authController.js
@@ -59,29 +59,30 @@ export const confirmarCuenta = async (req, res) => {
   
 // Login de usuario
 export const loginUsuario = async (req, res) => {
+  try {
     const { email, password } = req.body;
-  
+
     const usuario = await User.findOne({ email });
-  
+
     if (!usuario) {
       return res.status(404).json({ mensaje: 'Usuario no encontrado' });
     }
-  
+
     if (!usuario.confirmado) {
       return res.status(403).json({ mensaje: 'Tenés que confirmar tu cuenta primero' });
     }
-  
+
     const passwordValido = await bcrypt.compare(password, usuario.password);
     if (!passwordValido) {
       return res.status(401).json({ mensaje: 'Contraseña incorrecta' });
     }
-  
+
     const token = jwt.sign(
       { id: usuario._id, rol: usuario.rol },
       JWT_SECRET,
       { expiresIn: '7d' }
     );
-  
+
     res.status(200).json({
       mensaje: 'Login exitoso',
       token,
@@ -93,5 +94,9 @@ export const loginUsuario = async (req, res) => {
         foto: usuario.foto
       }
     });
-  };
+  } catch (error) {
+    console.error('Error en loginUsuario', error);
+    res.status(500).json({ mensaje: 'Error al iniciar sesión' });
+  }
+};
   


### PR DESCRIPTION
## Summary
- wrap `/api/auth/login` route in a try/catch to log errors and return a 500 instead of closing the connection
- add defensive error handling to `loginUsuario` controller for the same behavior

## Testing
- `node backend-auth/server.js >/tmp/server.log 2>&1 &`
- `curl -s -D - -H "Content-Type: application/json" -d '{"email":"test@example.com","password":"123"}' http://localhost:5000/api/auth/login --max-time 15`


------
https://chatgpt.com/codex/tasks/task_e_689d1e209d8483209dc8814ee2a091cc