### PR TITLE
fix excel export route import

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import nodemailer from 'nodemailer';
+import ExcelJS from 'exceljs';
 import User from './models/User.js';
 import Patinador from './models/Patinador.js';
 import { protegerRuta, permitirRol } from './middlewares/authMiddleware.js';
@@ -578,7 +579,6 @@ app.get(
   permitirRol('Delegado'),
   async (req, res) => {
     try {
-      const { default: ExcelJS } = await import('exceljs');
       const comp = await Competencia.findById(req.params.id).populate('listaBuenaFe');
       if (!comp) return res.status(404).json({ mensaje: 'Competencia no encontrada' });
 
@@ -720,9 +720,6 @@ app.get(
       await workbook.xlsx.write(res);
       res.end();
     } catch (err) {
-      if (err.code === 'ERR_MODULE_NOT_FOUND') {
-        return res.status(500).json({ mensaje: 'Dependencia exceljs no instalada' });
-      }
       console.error(err);
       res.status(500).json({ mensaje: 'Error al generar excel' });
     }


### PR DESCRIPTION
## Summary
- load ExcelJS at startup instead of dynamic import
- simplify Excel export route error handling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d212718f88320b4ea668f94e1f0be