### PR TITLE
Cargar ExcelJS dinámicamente en ruta de exportación

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -7,7 +7,6 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import nodemailer from 'nodemailer';
-import ExcelJS from 'exceljs';
 import User from './models/User.js';
 import Patinador from './models/Patinador.js';
 import { protegerRuta, permitirRol } from './middlewares/authMiddleware.js';
@@ -581,6 +580,16 @@ app.get(
     try {
       const comp = await Competencia.findById(req.params.id).populate('listaBuenaFe');
       if (!comp) return res.status(404).json({ mensaje: 'Competencia no encontrada' });
+
+      let ExcelJS;
+      try {
+        ExcelJS = (await import('exceljs')).default;
+      } catch (err) {
+        console.error('exceljs no instalado', err);
+        return res
+          .status(500)
+          .json({ mensaje: 'Dependencia exceljs no instalada' });
+      }
 
       const workbook = new ExcelJS.Workbook();
       const sheet = workbook.addWorksheet('Lista');


### PR DESCRIPTION
## Summary
- Avoid importing ExcelJS at startup to prevent crashes when the dependency is missing
- Load ExcelJS dynamically inside the Excel export route with clear error handling

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_689d2555e7288320b46cb23b1d848f2e