### PR TITLE
Fix Excel export to avoid connection reset

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -752,13 +752,16 @@ app.get(
         }
       });
 
+      const buffer = await workbook.xlsx.writeBuffer();
       res.setHeader(
         'Content-Type',
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
       );
-      res.setHeader('Content-Disposition', 'attachment; filename="lista_buena_fe.xlsx"');
-      await workbook.xlsx.write(res);
-      res.end();
+      res.setHeader(
+        'Content-Disposition',
+        'attachment; filename="lista_buena_fe.xlsx"'
+      );
+      res.send(Buffer.from(buffer));
     } catch (err) {
       console.error(err);
       res.status(500).json({ mensaje: 'Error al generar excel' });


### PR DESCRIPTION
## Summary
- send Excel export as buffer and send in response

## Testing
- `npm test` (backend-auth) *(fails: Missing script "test")*
- `npm test` (frontend-auth) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dd2a3d0008320bde7c3485942670d