### PR TITLE
Fix Lista Buena Fe column order and show runner numbers

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -720,8 +720,8 @@ app.get(
         row.getCell(1).value = idx + 1;
         row.getCell(2).value = 'SA';
         row.getCell(3).value = p.numeroCorredor;
-        row.getCell(4).value = p.categoria;
-        row.getCell(5).value = `${p.apellido} ${p.primerNombre}`;
+        row.getCell(4).value = `${p.apellido} ${p.primerNombre}`;
+        row.getCell(5).value = p.categoria;
         row.getCell(6).value = CLUB;
         row.getCell(7).value = new Date(p.fechaNacimiento).toLocaleDateString();
         row.getCell(8).value = p.dni;
@@ -733,7 +733,7 @@ app.get(
         row.commit();
 
         const next = lista[idx + 1];
-        const currL = getUltimaLetra(row.getCell(4).value);
+        const currL = getUltimaLetra(row.getCell(5).value);
         const nextL = next ? getUltimaLetra(next.categoria) : null;
         if (
           !next ||

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -229,6 +229,7 @@ export default function Torneos() {
                               <tr>
                                 <th>#</th>
                                 <th>Seguro</th>
+                                <th>Número</th>
                                 <th>Apellido y Nombre</th>
                                 <th>Categoría</th>
                                 <th>Club</th>
@@ -241,6 +242,7 @@ export default function Torneos() {
                                 <tr key={p._id}>
                                   <td>{idx + 1}</td>
                                   <td>SA</td>
+                                  <td>{p.numeroCorredor}</td>
                                   <td>
                                     {p.apellido} {p.primerNombre}
                                   </td>


### PR DESCRIPTION
## Summary
- swap name and category columns in Lista Buena Fe Excel export
- display runner number after Seguro in Lista Buena Fe table

## Testing
- `cd backend-auth && npm test` (fails: Missing script: "test")
- `cd frontend-auth && npm test` (fails: Missing script: "test")
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de47b867c832091538dd1983a3514