### PR TITLE
Separar datos del personal en columnas de Excel y resaltar filas finales

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -812,17 +812,41 @@ app.get(
       }
 
       const staff = [
-        'MANZUR VANESA CAROLINA TECN 08/07/1989 34543626',
-        'MANZUR GASTON ALFREDO DELEG 14/12/1983 30609550',
-        'CURA VANESA ELIZABEHT DELEG 24/02/1982 29301868'
+        {
+          name: 'MANZUR VANESA CAROLINA',
+          role: 'TECN',
+          birth: '08/07/1989',
+          dni: '34543626'
+        },
+        {
+          name: 'MANZUR GASTON ALFREDO',
+          role: 'DELEG',
+          birth: '14/12/1983',
+          dni: '30609550',
+          highlight: true
+        },
+        {
+          name: 'CURA VANESA ELIZABEHT',
+          role: 'DELEG',
+          birth: '24/02/1982',
+          dni: '29301868',
+          highlight: true
+        }
       ];
-      staff.forEach((text) => {
-        sheet.mergeCells(`D${rowNum}:H${rowNum}`);
-        const cell = sheet.getCell(`D${rowNum}`);
-        cell.value = text;
-        cell.alignment = { horizontal: 'center', vertical: 'middle' };
-        cell.border = allBorders;
-        sheet.getRow(rowNum).commit();
+
+      staff.forEach(({ name, role, birth, dni, highlight }) => {
+        const row = sheet.getRow(rowNum);
+        const values = [name, role, birth, dni];
+        values.forEach((value, idx) => {
+          const cell = row.getCell(4 + idx);
+          cell.value = value;
+          cell.alignment = { horizontal: 'center', vertical: 'middle' };
+          cell.border = allBorders;
+          if (highlight) {
+            cell.font = { color: { argb: 'FFFF0000' }, bold: true };
+          }
+        });
+        row.commit();
         rowNum++;
       });
 


### PR DESCRIPTION
## Summary
- Separar la información del personal en columnas independientes en el archivo Excel.
- Resaltar en rojo y negrita las últimas dos filas del personal.

## Testing
- `npm test` *(falló: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e1b0492fc8320be75957a7bdb31bd