### PR TITLE
Add PDF results upload for competitions

### DIFF
--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -14,6 +14,7 @@
     "mongoose": "^7.6.0",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.8",
-    "exceljs": "^4.3.0"
+    "exceljs": "^4.3.0",
+    "pdf-parse": "^1.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- allow uploading competition results as PDF and parse skater data
- record external skaters from parsed PDF into `patinadorexternos`
- add pdf-parse dependency

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0534d69188320bbf105abb8a03599