### PR TITLE
Fix Excel export and add PDF upload for competition results

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -18,6 +18,8 @@ import Torneo from './models/Torneo.js';
 import Competencia from './models/Competencia.js';
 import Resultado from './models/Resultado.js';
 import PatinadorExterno from './models/PatinadorExterno.js';
+import ExcelJS from 'exceljs';
+import pdfParse from 'pdf-parse';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -635,16 +637,6 @@ app.get(
       const comp = await Competencia.findById(req.params.id).populate('listaBuenaFe');
       if (!comp) return res.status(404).json({ mensaje: 'Competencia no encontrada' });
 
-      let ExcelJS;
-      try {
-        ExcelJS = (await import('exceljs')).default;
-      } catch (err) {
-        console.error('exceljs no instalado', err);
-        return res
-          .status(500)
-          .json({ mensaje: 'Dependencia exceljs no instalada' });
-      }
-
       const workbook = new ExcelJS.Workbook();
       const sheet = workbook.addWorksheet('Lista');
       sheet.getColumn(1).width = 1.89;
@@ -981,16 +973,6 @@ app.post(
   async (req, res) => {
     if (!req.file) {
       return res.status(400).json({ mensaje: 'Archivo no proporcionado' });
-    }
-    let pdfParse;
-    try {
-      pdfParse = (await import('pdf-parse')).default;
-    } catch (err) {
-      console.error('pdf-parse no disponible', err);
-      fs.unlinkSync(req.file.path);
-      return res
-        .status(500)
-        .json({ mensaje: 'Dependencia pdf-parse no instalada' });
     }
     try {
       const buffer = fs.readFileSync(req.file.path);

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -135,6 +135,24 @@ export default function Torneos() {
     }
   };
 
+  const cargarPdfPuntajes = async (e, compId) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('archivo', file);
+    try {
+      await api.post(`/competitions/${compId}/resultados/pdf`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      alert('PDF procesado correctamente');
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.mensaje || 'Error al procesar PDF');
+    } finally {
+      e.target.value = '';
+    }
+  };
+
   const agregarResultado = async (e, compId) => {
     e.preventDefault();
     const { nombre, club, numero, puntos, categoria } = e.target;
@@ -224,6 +242,12 @@ export default function Torneos() {
                           >
                             Exportar Excel
                           </button>
+                          <input
+                            type="file"
+                            accept="application/pdf"
+                            className="form-control mb-2"
+                            onChange={(e) => cargarPdfPuntajes(e, c._id)}
+                          />
                           <table className="table text-center">
                             <thead>
                               <tr>


### PR DESCRIPTION
## Summary
- preload exceljs and pdf-parse modules to avoid runtime import errors
- add PDF score upload interface in competition view

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0bcc8df38832094e340916d3f68c3