### PR TITLE
fix: avoid proxy connection errors by using direct backend URL

### DIFF
--- a/frontend-auth/src/api.js
+++ b/frontend-auth/src/api.js
@@ -2,11 +2,12 @@ import axios from 'axios';
 
 // Axios instance that automatically attaches the JWT token from localStorage
 // Use the API URL from environment variables when available. If it is not
-// provided, fall back to a relative `/api` path so the frontend can work
-// regardless of where the backend is hosted. During development the Vite
-// proxy will redirect these calls to the backend server.
+// provided, fall back to `http://localhost:5000/api` so the frontend
+// connects directly to the backend without relying on Vite's dev proxy.
+// This avoids proxy connection errors when the dev server cannot reach the
+// backend.
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api'
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api'
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend-auth/vite.config.js
+++ b/frontend-auth/vite.config.js
@@ -4,15 +4,11 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // Proxy API requests during development so the frontend can use a relative
-  // `/api` path regardless of where the backend runs. This also proxies
-  // requests for uploaded files.
+  // Proxy only uploaded files during development. API requests now use an
+  // absolute backend URL defined in `src/api.js`, which avoids development
+  // proxy connection issues.
   server: {
     proxy: {
-      '/api': {
-        target: 'http://localhost:5000',
-        changeOrigin: true
-      },
       '/uploads': {
         target: 'http://localhost:5000',
         changeOrigin: true


### PR DESCRIPTION
## Summary
- send API requests directly to http://localhost:5000 to bypass dev proxy
- only proxy uploads during development to prevent repeated Vite proxy errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1036aae648320b2efefc013e267fa