### PR TITLE
Fix PDF parsing import to avoid missing file error

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -978,7 +978,13 @@ app.post(
     }
     try {
       const buffer = fs.readFileSync(req.file.path);
-      const pdfParse = (await import('pdf-parse')).default;
+      // Importar directamente la implementación principal de pdf-parse para
+      // evitar la carga del archivo de prueba inexistente que provoca el
+      // error ENOENT. El paquete expone la funcionalidad en
+      // "lib/pdf-parse.js" sin dependencias a archivos externos.
+      const pdfParse = (
+        await import('pdf-parse/lib/pdf-parse.js')
+      ).default;
       const data = await pdfParse(buffer);
       const lines = data.text
         .split('\n')


### PR DESCRIPTION
## Summary
- import pdf-parse from its lib implementation to stop referencing non-existent test files during uploads

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a109a2b67483209ff000904801be09