### PR TITLE
Add separate score table page for competitions

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -15,6 +15,7 @@ import AsociarPatinadores from './pages/AsociarPatinadores';
 import Notificaciones from './pages/Notificaciones';
 import CrearNotificacion from './pages/CrearNotificacion';
 import Torneos from './pages/Torneos';
+import TablaPuntos from './pages/TablaPuntos';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -58,7 +59,11 @@ function AppRoutes() {
         <Route path="/asociar-patinadores" element={<ProtectedRoute><AsociarPatinadores /></ProtectedRoute>} />
         <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />
         <Route path="/notificaciones" element={<ProtectedRoute><Notificaciones /></ProtectedRoute>} />
-        <Route path="/torneos" element={<ProtectedRoute><Torneos /></ProtectedRoute>} />
+          <Route path="/torneos" element={<ProtectedRoute><Torneos /></ProtectedRoute>} />
+          <Route
+            path="/torneos/:id/tabla-puntos"
+            element={<ProtectedRoute><TablaPuntos /></ProtectedRoute>}
+          />
       </Routes>
     </>
   );

--- a/frontend-auth/src/pages/TablaPuntos.jsx
+++ b/frontend-auth/src/pages/TablaPuntos.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api.js';
+
+export default function TablaPuntos() {
+  const { id } = useParams();
+  const [puntos, setPuntos] = useState([]);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get(`/competitions/${id}/puntajes`);
+        setPuntos(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    cargar();
+  }, [id]);
+
+  return (
+    <div className="container mt-4">
+      <h2>Tabla de puntos</h2>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Nombre</th>
+            <th>Número</th>
+            <th>Club</th>
+            <th>Puntos</th>
+          </tr>
+        </thead>
+        <tbody>
+          {puntos.map((p, idx) => (
+            <tr key={`${p.nombre}-${p.numero}-${idx}`}>
+              <td>{idx + 1}</td>
+              <td>{p.nombre}</td>
+              <td>{p.numero}</td>
+              <td>{p.club}</td>
+              <td>{p.puntosTotales}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import api from '../api.js';
 
 export default function Torneos() {
@@ -336,7 +337,7 @@ export default function Torneos() {
                             </tr>
                           </thead>
                           <tbody>
-                            {(detalles[c._id].tablaPuntos || []).map((p) => (
+                          {(detalles[c._id].tablaPuntos || []).map((p) => (
                               <tr key={`${p.numero}-${p.club}-${p.nombre}`}>
                                 <td>{p.nombre}</td>
                                 <td>{p.numero}</td>
@@ -346,6 +347,14 @@ export default function Torneos() {
                           ))}
                         </tbody>
                       </table>
+                      <div className="mt-2">
+                        <Link
+                          to={`/torneos/${c._id}/tabla-puntos`}
+                          className="btn btn-secondary btn-sm"
+                        >
+                          Ver en página aparte
+                        </Link>
+                      </div>
                       {detalles[c._id].externos.length > 0 && (
                         <div className="mt-3">
                           <h6>Patinadores externos</h6>


### PR DESCRIPTION
## Summary
- Add dedicated TablaPuntos page to show competition score tables
- Route competitions to TablaPuntos and link from Torneos page
- Provide navigation to view full score table outside tournament panel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2f6c4a6ec8320b88d06fd5a732327