### PR TITLE
Handle missing tesseract.js dependency gracefully

### DIFF
--- a/backend-auth/services/ocrService.js
+++ b/backend-auth/services/ocrService.js
@@ -1,8 +1,18 @@
-import Tesseract from 'tesseract.js';
-import { readFile } from 'fs/promises';
-
 // Servicio simple de OCR usando tesseract.js
+// Se realiza una importación dinámica para evitar que la ausencia del
+// paquete detenga la ejecución del servidor. Si el paquete no está
+// instalado se lanza un error descriptivo.
 export async function ocrBuffer(buffer) {
+  // Carga perezosa de tesseract.js
+  let Tesseract;
+  try {
+    ({ default: Tesseract } = await import('tesseract.js'));
+  } catch {
+    throw new Error(
+      "tesseract.js no está instalado. Ejecute 'npm install tesseract.js'"
+    );
+  }
+
   const { data } = await Tesseract.recognize(buffer, 'spa', {
     logger: () => {}
   });


### PR DESCRIPTION
## Summary
- load tesseract.js lazily in ocr service
- provide descriptive error when dependency is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a34bd33a948320981669ab0493b748