### PR TITLE
feat(frontend): add tournaments section

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -15,6 +15,7 @@ import AsociarPatinadores from './pages/AsociarPatinadores';
 import Notificaciones from './pages/Notificaciones';
 import CrearNotificacion from './pages/CrearNotificacion';
 import ImportarPuntajesPDF from './pages/ImportarPuntajesPDF';
+import Torneos from './pages/Torneos';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -29,6 +30,7 @@ function AppRoutes() {
       <Routes>
         <Route path="/" element={<Auth />} />
         <Route path="/home" element={<Home />} />
+        <Route path="/torneos" element={<ProtectedRoute><Torneos /></ProtectedRoute>} />
         <Route path="/google-success" element={<GoogleSuccess />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
         <Route

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -65,6 +65,7 @@ export default function Navbar() {
   const navItems = isLoggedIn
     ? [
         { label: 'Inicio', path: '/home' },
+        { label: 'Torneos', path: '/torneos' },
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [
               {

--- a/frontend-auth/src/components/importaciones/ImportarPuntajesPDF.jsx
+++ b/frontend-auth/src/components/importaciones/ImportarPuntajesPDF.jsx
@@ -7,7 +7,6 @@ import usePDFExtraction from '../../hooks/usePDFExtraction.js';
 export default function ImportarPuntajesPDF() {
   const [step, setStep] = useState(1);
   const [competenciaId, setCompetenciaId] = useState(null);
-  const [columnMapping, setColumnMapping] = useState(null);
   const { extraction, loading, error, extract, confirm } = usePDFExtraction();
   const [summary, setSummary] = useState(null);
 
@@ -18,7 +17,6 @@ export default function ImportarPuntajesPDF() {
   };
 
   const handleConfirm = async (mapping) => {
-    setColumnMapping(mapping);
     const res = await confirm({ extractionId: extraction.extractionId, competenciaId, columnMapping: mapping });
     setSummary(res);
     setStep(3);

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+export default function Torneos() {
+  const [torneos, setTorneos] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get('/tournaments');
+        setTorneos(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('Error al cargar torneos');
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargar();
+  }, []);
+
+  if (loading) return <div className="container mt-3">Cargando torneos...</div>;
+  if (error) return <div className="container mt-3 text-danger">{error}</div>;
+
+  return (
+    <div className="container mt-3">
+      <h2>Torneos</h2>
+      {torneos.length === 0 ? (
+        <p>No hay torneos disponibles.</p>
+      ) : (
+        <ul className="list-group">
+          {torneos.map((t) => (
+            <li key={t._id} className="list-group-item">
+              <strong>{t.nombre}</strong>
+              <div>
+                {new Date(t.fechaInicio).toLocaleDateString()} - {new Date(t.fechaFin).toLocaleDateString()}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose Torneos link in navbar and wire up route
- display tournaments page with basic list
- drop unused state from PDF import flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a44607f4088320824331dfea2df3fb