### PR TITLE
Add competition management and good faith list export

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -16,6 +16,8 @@ import Notificaciones from './pages/Notificaciones';
 import CrearNotificacion from './pages/CrearNotificacion';
 import ImportarPuntajesPDF from './pages/ImportarPuntajesPDF';
 import Torneos from './pages/Torneos';
+import Competencias from './pages/Competencias';
+import ListaBuenaFe from './pages/ListaBuenaFe';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -31,6 +33,11 @@ function AppRoutes() {
         <Route path="/" element={<Auth />} />
         <Route path="/home" element={<Home />} />
         <Route path="/torneos" element={<ProtectedRoute><Torneos /></ProtectedRoute>} />
+        <Route path="/torneos/:id" element={<ProtectedRoute><Competencias /></ProtectedRoute>} />
+        <Route
+          path="/competencias/:id/lista"
+          element={<ProtectedRoute roles={['Delegado']}><ListaBuenaFe /></ProtectedRoute>}
+        />
         <Route path="/google-success" element={<GoogleSuccess />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
         <Route

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import api from '../api';
+
+export default function Competencias() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const rol = localStorage.getItem('rol');
+  const [competencias, setCompetencias] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [nombre, setNombre] = useState('');
+  const [fecha, setFecha] = useState('');
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get(`/tournaments/${id}/competitions`);
+        setCompetencias(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('Error al cargar competencias');
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargar();
+  }, [id]);
+
+  const crearCompetencia = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post(`/tournaments/${id}/competitions`, { nombre, fecha });
+      setNombre('');
+      setFecha('');
+      const res = await api.get(`/tournaments/${id}/competitions`);
+      setCompetencias(res.data);
+    } catch (err) {
+      console.error(err);
+      alert('Error al crear competencia');
+    }
+  };
+
+  if (loading) return <div className="container mt-3">Cargando competencias...</div>;
+  if (error) return <div className="container mt-3 text-danger">{error}</div>;
+
+  return (
+    <div className="container mt-3">
+      <h2>Competencias</h2>
+      {rol === 'Delegado' && (
+        <form onSubmit={crearCompetencia} className="row g-2 mb-3">
+          <div className="col-md-5">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Nombre"
+              value={nombre}
+              onChange={(e) => setNombre(e.target.value)}
+              required
+            />
+          </div>
+          <div className="col-md-4">
+            <input
+              type="date"
+              className="form-control"
+              value={fecha}
+              onChange={(e) => setFecha(e.target.value)}
+              required
+            />
+          </div>
+          <div className="col-md-3">
+            <button type="submit" className="btn btn-primary w-100">
+              Crear
+            </button>
+          </div>
+        </form>
+      )}
+      {competencias.length === 0 ? (
+        <p>No hay competencias registradas.</p>
+      ) : (
+        <ul className="list-group">
+          {competencias.map((c) => (
+            <li key={c._id} className="list-group-item d-flex justify-content-between align-items-center">
+              <div>
+                <strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}
+              </div>
+              {rol === 'Delegado' && (
+                <button
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => navigate(`/competencias/${c._id}/lista`)}
+                >
+                  Lista Buena Fe
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/ListaBuenaFe.jsx
+++ b/frontend-auth/src/pages/ListaBuenaFe.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+
+export default function ListaBuenaFe() {
+  const { id } = useParams();
+  const [lista, setLista] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get(`/competitions/${id}/lista-buena-fe`);
+        setLista(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('Error al cargar lista');
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargar();
+  }, [id]);
+
+  const exportar = async () => {
+    try {
+      const res = await api.get(`/competitions/${id}/lista-buena-fe/excel`, {
+        responseType: 'blob'
+      });
+      const url = window.URL.createObjectURL(new Blob([res.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'lista_buena_fe.xlsx');
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      console.error(err);
+      alert('Error al exportar');
+    }
+  };
+
+  if (loading) return <div className="container mt-3">Cargando lista...</div>;
+  if (error) return <div className="container mt-3 text-danger">{error}</div>;
+
+  return (
+    <div className="container mt-3">
+      <h2>Lista de Buena Fe</h2>
+      <button className="btn btn-success mb-3" onClick={exportar}>
+        Exportar a Excel
+      </button>
+      {lista.length === 0 ? (
+        <p>No hay patinadores en la lista.</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Apellido y Nombre</th>
+              <th>Categoría</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lista.map((p, idx) => (
+              <tr key={p._id || idx}>
+                <td>{idx + 1}</td>
+                <td>
+                  {p.apellido} {p.primerNombre}
+                </td>
+                <td>{p.categoria}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api from '../api';
 
 export default function Torneos() {
   const [torneos, setTorneos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const cargar = async () => {
@@ -32,11 +34,19 @@ export default function Torneos() {
       ) : (
         <ul className="list-group">
           {torneos.map((t) => (
-            <li key={t._id} className="list-group-item">
-              <strong>{t.nombre}</strong>
+            <li key={t._id} className="list-group-item d-flex justify-content-between align-items-center">
               <div>
-                {new Date(t.fechaInicio).toLocaleDateString()} - {new Date(t.fechaFin).toLocaleDateString()}
+                <strong>{t.nombre}</strong>
+                <div>
+                  {new Date(t.fechaInicio).toLocaleDateString()} - {new Date(t.fechaFin).toLocaleDateString()}
+                </div>
               </div>
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => navigate(`/torneos/${t._id}`)}
+              >
+                Ver Competencias
+              </button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- Add competitions page to create and list competitions for a tournament
- Link tournaments to competition management
- Provide good faith list page with Excel export

## Testing
- `npm test` (frontend) *(fails: missing script)*
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68a4483d47c483208b0eb62552f706db