### PR TITLE
Add PDF result import and display per competition

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -16,6 +16,7 @@ import News from './models/News.js';
 import Notification from './models/Notification.js';
 import Torneo from './models/Torneo.js';
 import Competencia from './models/Competencia.js';
+import Resultado from './models/Resultado.js';
 import ExcelJS from 'exceljs';
 import importacionesRoutes from './routes/importaciones.js';
 
@@ -579,6 +580,16 @@ app.post(
   }
 );
 
+app.get('/api/competencias', protegerRuta, async (req, res) => {
+  try {
+    const comps = await Competencia.find().sort({ fecha: 1 });
+    res.json(comps);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al obtener competencias' });
+  }
+});
+
 app.get('/api/tournaments/:id/competitions', protegerRuta, async (req, res) => {
   try {
     const comps = await Competencia.find({ torneo: req.params.id }).sort({ fecha: 1 });
@@ -586,6 +597,18 @@ app.get('/api/tournaments/:id/competitions', protegerRuta, async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ mensaje: 'Error al obtener competencias' });
+  }
+});
+
+app.get('/api/competitions/:id/resultados', protegerRuta, async (req, res) => {
+  try {
+    const resultados = await Resultado.find({ competenciaId: req.params.id })
+      .populate('deportistaId', 'primerNombre segundoNombre apellido')
+      .sort({ categoria: 1, posicion: 1 });
+    res.json(resultados);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al obtener resultados' });
   }
 });
 

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -18,6 +18,7 @@ import ImportarPuntajesPDF from './pages/ImportarPuntajesPDF';
 import Torneos from './pages/Torneos';
 import Competencias from './pages/Competencias';
 import ListaBuenaFe from './pages/ListaBuenaFe';
+import ResultadosCompetencia from './pages/ResultadosCompetencia';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -37,6 +38,14 @@ function AppRoutes() {
         <Route
           path="/competencias/:id/lista"
           element={<ProtectedRoute roles={['Delegado']}><ListaBuenaFe /></ProtectedRoute>}
+        />
+        <Route
+          path="/competencias/:id/resultados"
+          element={<ProtectedRoute><ResultadosCompetencia /></ProtectedRoute>}
+        />
+        <Route
+          path="/competencias/:id/importar-puntajes"
+          element={<ProtectedRoute roles={['Delegado']}><ImportarPuntajesPDF /></ProtectedRoute>}
         />
         <Route path="/google-success" element={<GoogleSuccess />} />
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />

--- a/frontend-auth/src/components/importaciones/ImportarPuntajesPDF.jsx
+++ b/frontend-auth/src/components/importaciones/ImportarPuntajesPDF.jsx
@@ -4,9 +4,9 @@ import PasoMapeo from './PasoMapeo.jsx';
 import PasoConfirmacion from './PasoConfirmacion.jsx';
 import usePDFExtraction from '../../hooks/usePDFExtraction.js';
 
-export default function ImportarPuntajesPDF() {
+export default function ImportarPuntajesPDF({ competenciaId: initialCompetenciaId }) {
   const [step, setStep] = useState(1);
-  const [competenciaId, setCompetenciaId] = useState(null);
+  const [competenciaId, setCompetenciaId] = useState(initialCompetenciaId || null);
   const { extraction, loading, error, extract, confirm } = usePDFExtraction();
   const [summary, setSummary] = useState(null);
 
@@ -26,7 +26,7 @@ export default function ImportarPuntajesPDF() {
     <div>
       {loading && <p>Cargando...</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
-      {step === 1 && <PasoSubida onSubmit={handleUpload} />}
+      {step === 1 && <PasoSubida onSubmit={handleUpload} defaultCompetenciaId={competenciaId} />}
       {step === 2 && extraction && (
         <PasoMapeo
           detectedColumns={extraction.detectedColumns}

--- a/frontend-auth/src/components/importaciones/PasoSubida.jsx
+++ b/frontend-auth/src/components/importaciones/PasoSubida.jsx
@@ -1,34 +1,40 @@
 import { useEffect, useState } from 'react';
 import api from '../../api';
 
-export default function PasoSubida({ onSubmit }) {
+export default function PasoSubida({ onSubmit, defaultCompetenciaId }) {
   const [competencias, setCompetencias] = useState([]);
-  const [competenciaId, setCompetenciaId] = useState('');
+  const [competenciaId, setCompetenciaId] = useState(defaultCompetenciaId || '');
   const [file, setFile] = useState(null);
 
   useEffect(() => {
-    api.get('/competencias').then((r) => setCompetencias(r.data));
-  }, []);
+    if (!defaultCompetenciaId) {
+      api.get('/competencias').then((r) => setCompetencias(r.data));
+    }
+  }, [defaultCompetenciaId]);
 
   const handle = (e) => {
     e.preventDefault();
-    if (competenciaId && file) onSubmit(competenciaId, file);
+    const comp = competenciaId || defaultCompetenciaId;
+    if (comp && file) onSubmit(comp, file);
   };
 
   return (
     <form onSubmit={handle}>
       <h3>Subir PDF de puntajes</h3>
-      <label>
-        Competencia:
-        <select value={competenciaId} onChange={(e) => setCompetenciaId(e.target.value)} required>
-          <option value="">Seleccione...</option>
-          {competencias.map((c) => (
-            <option key={c._id} value={c._id}>
-              {c.nombre}
-            </option>
-          ))}
-        </select>
-      </label>
+      {!defaultCompetenciaId && (
+        <label>
+          Competencia:
+          <select value={competenciaId} onChange={(e) => setCompetenciaId(e.target.value)} required>
+            <option value="">Seleccione...</option>
+            {competencias.map((c) => (
+              <option key={c._id} value={c._id}>
+                {c.nombre}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {defaultCompetenciaId && <p>Competencia seleccionada</p>}
       <input type="file" accept="application/pdf" onChange={(e) => setFile(e.target.files[0])} />
       <button type="submit">Extraer</button>
     </form>

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -84,14 +84,30 @@ export default function Competencias() {
               <div>
                 <strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}
               </div>
-              {rol === 'Delegado' && (
+              <div className="d-flex gap-2">
+                {rol === 'Delegado' && (
+                  <>
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => navigate(`/competencias/${c._id}/lista`)}
+                    >
+                      Lista Buena Fe
+                    </button>
+                    <button
+                      className="btn btn-primary btn-sm"
+                      onClick={() => navigate(`/competencias/${c._id}/importar-puntajes`)}
+                    >
+                      Importar Puntajes
+                    </button>
+                  </>
+                )}
                 <button
-                  className="btn btn-secondary btn-sm"
-                  onClick={() => navigate(`/competencias/${c._id}/lista`)}
+                  className="btn btn-info btn-sm"
+                  onClick={() => navigate(`/competencias/${c._id}/resultados`)}
                 >
-                  Lista Buena Fe
+                  Ver Resultados
                 </button>
-              )}
+              </div>
             </li>
           ))}
         </ul>

--- a/frontend-auth/src/pages/ImportarPuntajesPDF.jsx
+++ b/frontend-auth/src/pages/ImportarPuntajesPDF.jsx
@@ -1,9 +1,11 @@
+import { useParams } from 'react-router-dom';
 import ImportarPuntajesPDF from '../components/importaciones/ImportarPuntajesPDF.jsx';
 
 export default function ImportarPuntajesPDFPage() {
+  const { id } = useParams();
   return (
     <div style={{ padding: 20 }}>
-      <ImportarPuntajesPDF />
+      <ImportarPuntajesPDF competenciaId={id} />
     </div>
   );
 }

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+
+export default function ResultadosCompetencia() {
+  const { id } = useParams();
+  const [resultados, setResultados] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get(`/competitions/${id}/resultados`);
+        setResultados(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('Error al cargar resultados');
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargar();
+  }, [id]);
+
+  if (loading) return <div className="container mt-3">Cargando resultados...</div>;
+  if (error) return <div className="container mt-3 text-danger">{error}</div>;
+  if (resultados.length === 0) return <div className="container mt-3">No hay resultados cargados.</div>;
+
+  return (
+    <div className="container mt-3">
+      <h2>Resultados</h2>
+      <div className="table-responsive">
+        <table className="table table-striped">
+          <thead>
+            <tr>
+              <th>Categoría</th>
+              <th>Posición</th>
+              <th>Nombre</th>
+              <th>Tiempo (ms)</th>
+              <th>Puntos</th>
+              <th>Dorsal</th>
+            </tr>
+          </thead>
+          <tbody>
+            {resultados.map((r) => (
+              <tr key={r._id}>
+                <td>{r.categoria}</td>
+                <td>{r.posicion}</td>
+                <td>{`${r.deportistaId?.primerNombre || ''} ${r.deportistaId?.segundoNombre || ''} ${r.deportistaId?.apellido || ''}`.trim()}</td>
+                <td>{r.tiempoMs}</td>
+                <td>{r.puntos}</td>
+                <td>{r.dorsal}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- allow delegados to import competition scores from PDF with preselected competition
- expose API endpoints to list competitions and fetch stored results
- show results table for each competition

## Testing
- `npm test` in backend-auth
- `npm run lint` in frontend-auth

------
https://chatgpt.com/codex/tasks/task_e_68a44b93bdc083208661c8945e9c26e2