### PR TITLE
Improve PDF extraction header detection

### DIFF
--- a/backend-auth/services/__tests__/tablaExtractor.test.js
+++ b/backend-auth/services/__tests__/tablaExtractor.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mapHeaders } from '../tablaExtractor.js';
+import { mapHeaders, extractTableFromText } from '../tablaExtractor.js';
 
 test('mapea encabezados con sinónimos', () => {
   const headers = ['Puesto', 'N°', 'Apellido y Nombre', 'Categoría', 'Club', 'Tiempo', 'Pts'];
@@ -12,4 +12,38 @@ test('mapea encabezados con sinónimos', () => {
   assert.equal(mapping.club, 4);
   assert.equal(mapping.tiempo, 5);
   assert.equal(mapping.puntos, 6);
+});
+
+test('reconoce encabezados abreviados y tabla separada por espacios', () => {
+  const text =
+    'Orden  Nro atleta  Apellido y nombres  categoria  club  pos  ptos\n' +
+    '1      25          Perez Juan         Juvenil    Club A  1   10';
+  const { headers, rows } = extractTableFromText(text);
+  assert.deepEqual(headers, [
+    'Orden',
+    'Nro atleta',
+    'Apellido y nombres',
+    'categoria',
+    'club',
+    'pos',
+    'ptos'
+  ]);
+
+  const mapping = mapHeaders(headers);
+  assert.equal(mapping.dorsal, 1);
+  assert.equal(mapping.nombre, 2);
+  assert.equal(mapping.categoria, 3);
+  assert.equal(mapping.club, 4);
+  assert.equal(mapping.posicion, 5);
+  assert.equal(mapping.puntos, 6);
+
+  assert.deepEqual(rows[0], [
+    '1',
+    '25',
+    'Perez Juan',
+    'Juvenil',
+    'Club A',
+    '1',
+    '10'
+  ]);
 });

--- a/backend-auth/services/tablaExtractor.js
+++ b/backend-auth/services/tablaExtractor.js
@@ -2,13 +2,17 @@
 
 // Tabla de sinónimos para las columnas
 export const SINONIMOS = {
-  posicion: ['puesto', 'posicion', 'rank'],
-  dorsal: ['nº', 'numero', 'n°', 'bib'],
-  nombre: ['apellido y nombre', 'nombre'],
+  // Posición dentro de la competencia (a veces abreviado como "pos")
+  posicion: ['puesto', 'posicion', 'rank', 'pos'],
+  // Número de atleta o dorsal
+  dorsal: ['nº', 'numero', 'n°', 'bib', 'nro', 'nro atleta'],
+  // Nombre completo del deportista
+  nombre: ['apellido y nombre', 'apellido y nombres', 'apellidos y nombres', 'nombre'],
   categoria: ['categoria', 'cat', 'division', 'div'],
   club: ['club', 'equipo', 'institucion'],
   tiempo: ['tiempo', 'tiempo oficial'],
-  puntos: ['puntos', 'pts', 'score']
+  // Puntos obtenidos (ptos, pts, score)
+  puntos: ['puntos', 'pts', 'score', 'ptos']
 };
 
 const normalizar = (str = '') =>
@@ -33,15 +37,22 @@ export function mapHeaders(headerRow = []) {
   return mapping;
 }
 
-// Extrae una tabla simple de texto usando separadores de | o espacios múltiples
+// Extrae una tabla simple de texto usando separadores de `|` o, si no existen,
+// columnas separadas por dos o más espacios. Esto preserva los valores que
+// contienen espacios internos como "Apellido y nombres".
 export function extractTableFromText(text) {
   const lines = text
     .split(/\r?\n/)
-    .map((l) => l.replace(/\s+/g, ' ').trim())
+    .map((l) => l.trim())
     .filter(Boolean);
   if (lines.length === 0) return { headers: [], rows: [] };
-  const delimiter = lines[0].includes('|') ? '|' : ' ';
-  const splitLine = (line) => line.split(delimiter).map((c) => c.trim());
+
+  const usesPipe = lines[0].includes('|');
+  const splitLine = (line) =>
+    usesPipe
+      ? line.split('|').map((c) => c.trim())
+      : line.split(/\s{2,}/).map((c) => c.trim()).filter(Boolean);
+
   const headers = splitLine(lines[0]);
   const rows = lines.slice(1).map(splitLine).filter((r) => r.some(Boolean));
   return { headers, rows };


### PR DESCRIPTION
## Summary
- handle PDF tables separated by multiple spaces instead of single space
- map more header variants such as "Nro atleta", "pos" and "ptos"
- test PDF extraction with abbreviated Spanish headers

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4f4a4df7483209a99934d57f0363f