### PR TITLE
Fix PDF score header mapping for repeated columns and typos

### DIFF
--- a/backend-auth/services/__tests__/tablaExtractor.test.js
+++ b/backend-auth/services/__tests__/tablaExtractor.test.js
@@ -34,7 +34,7 @@ test('reconoce encabezados abreviados y tabla separada por espacios', () => {
   assert.equal(mapping.nombre, 2);
   assert.equal(mapping.categoria, 3);
   assert.equal(mapping.club, 4);
-  assert.equal(mapping.posicion, 5);
+  assert.equal(mapping.posicion, 0);
   assert.equal(mapping.puntos, 6);
 
   assert.deepEqual(rows[0], [
@@ -46,4 +46,27 @@ test('reconoce encabezados abreviados y tabla separada por espacios', () => {
     '1',
     '10'
   ]);
+});
+
+test('maneja encabezados repetidos y variaciones tipográficas', () => {
+  const headers = [
+    'Orden',
+    'Nro Atleta',
+    'APELLIDO Y NOBRES',
+    'CATEGORIA',
+    'CLUB',
+    'Nro Atleta',
+    'POS',
+    'PTOS',
+    'Nro Atleta',
+    'POS',
+    'PTOS TOTAL'
+  ];
+  const mapping = mapHeaders(headers);
+  assert.equal(mapping.posicion, 0);
+  assert.equal(mapping.dorsal, 1); // primera ocurrencia
+  assert.equal(mapping.nombre, 2);
+  assert.equal(mapping.categoria, 3);
+  assert.equal(mapping.club, 4);
+  assert.equal(mapping.puntos, 10); // columna "PTOS TOTAL"
 });

--- a/backend-auth/services/tablaExtractor.js
+++ b/backend-auth/services/tablaExtractor.js
@@ -3,16 +3,23 @@
 // Tabla de sinónimos para las columnas
 export const SINONIMOS = {
   // Posición dentro de la competencia (a veces abreviado como "pos")
-  posicion: ['puesto', 'posicion', 'rank', 'pos'],
+  posicion: ['puesto', 'posicion', 'rank', 'pos', 'orden'],
   // Número de atleta o dorsal
   dorsal: ['nº', 'numero', 'n°', 'bib', 'nro', 'nro atleta'],
   // Nombre completo del deportista
-  nombre: ['apellido y nombre', 'apellido y nombres', 'apellidos y nombres', 'nombre'],
+  nombre: [
+    'apellido y nombre',
+    'apellido y nombres',
+    'apellidos y nombres',
+    'apellido y nobres',
+    'apellidos y nobres',
+    'nombre'
+  ],
   categoria: ['categoria', 'cat', 'division', 'div'],
   club: ['club', 'equipo', 'institucion'],
   tiempo: ['tiempo', 'tiempo oficial'],
   // Puntos obtenidos (ptos, pts, score)
-  puntos: ['puntos', 'pts', 'score', 'ptos']
+  puntos: ['puntos', 'pts', 'score', 'ptos', 'ptos total', 'puntos total', 'pts total']
 };
 
 const normalizar = (str = '') =>
@@ -30,7 +37,9 @@ export function mapHeaders(headerRow = []) {
     const limpio = normalizar(col);
     for (const [campo, sinonimos] of Object.entries(SINONIMOS)) {
       if (limpio === campo || sinonimos.includes(limpio)) {
-        mapping[campo] = idx;
+        if (campo === 'puntos' || !(campo in mapping)) {
+          mapping[campo] = idx;
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- handle PDF score tables with repeated columns and typos
- map final total points column instead of intermediate scores
- expand tests for header variations and repeats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59c1dd6b48320b337abb57bdcf833