### PR TITLE
refactor: use crypto for md5 hashing

### DIFF
--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -14,7 +14,6 @@
     "express": "^4.21.1",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "md5": "^2.3.0",
     "mongoose": "^7.6.0",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.8",

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -18,7 +18,6 @@ import Torneo from './models/Torneo.js';
 import Competencia from './models/Competencia.js';
 import Resultado from './models/Resultado.js';
 import ExcelJS from 'exceljs';
-import md5 from 'md5';
 import parseResultadosPdf from './utils/parseResultadosPdf.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -627,7 +626,7 @@ app.post(
       }
       const buffer = fs.readFileSync(req.file.path);
       fs.unlinkSync(req.file.path);
-      const hash = md5(buffer);
+      const hash = crypto.createHash('md5').update(buffer).digest('hex');
       const filas = await parseResultadosPdf(buffer);
       let count = 0;
       for (const fila of filas) {


### PR DESCRIPTION
## Summary
- remove md5 dependency
- use Node's crypto module to generate hashes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60face1b88320b98ebee2c3a442db