### PR TITLE
Prevent pdf-parse debug code from running in ESM

### DIFF
--- a/backend-auth/utils/parseResultadosPdf.js
+++ b/backend-auth/utils/parseResultadosPdf.js
@@ -1,4 +1,4 @@
-import pdf from 'pdf-parse';
+import pdf from 'pdf-parse/lib/pdf-parse.js';
 
 function tiempoTextoAMs(t) {
   const match = t.match(/(?:(\d+):)?(\d{1,2})(?:\.(\d{1,3}))?/);


### PR DESCRIPTION
## Summary
- import pdf-parse directly from its library file to avoid executing bundled debug script in ESM environments

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68a611d40c90832086f27fc5bc3cb016