### PR TITLE
feat: allow manual result entry with external skaters

### DIFF
--- a/backend-auth/models/PatinadorExterno.js
+++ b/backend-auth/models/PatinadorExterno.js
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+
+const patinadorExternoSchema = new mongoose.Schema(
+  {
+    primerNombre: { type: String, required: true },
+    segundoNombre: { type: String },
+    apellido: { type: String, required: true },
+    club: { type: String, required: true }
+  },
+  { timestamps: true }
+);
+
+patinadorExternoSchema.index(
+  { primerNombre: 1, segundoNombre: 1, apellido: 1, club: 1 },
+  { unique: true }
+);
+
+export default mongoose.model('PatinadorExterno', patinadorExternoSchema);

--- a/backend-auth/models/Resultado.js
+++ b/backend-auth/models/Resultado.js
@@ -2,8 +2,25 @@ import mongoose from 'mongoose';
 
 const resultadoSchema = new mongoose.Schema(
   {
-    competenciaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia', required: true },
-    deportistaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Patinador', required: true },
+    competenciaId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Competencia',
+      required: true
+    },
+    deportistaId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Patinador',
+      required: function () {
+        return !this.invitadoId;
+      }
+    },
+    invitadoId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'PatinadorExterno',
+      required: function () {
+        return !this.deportistaId;
+      }
+    },
     categoria: { type: String, required: true },
     clubId: { type: mongoose.Schema.Types.ObjectId, ref: 'Club' },
     posicion: Number,
@@ -19,6 +36,13 @@ const resultadoSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-resultadoSchema.index({ competenciaId: 1, deportistaId: 1, categoria: 1 }, { unique: true });
+resultadoSchema.index(
+  { competenciaId: 1, deportistaId: 1, categoria: 1 },
+  { unique: true, sparse: true }
+);
+resultadoSchema.index(
+  { competenciaId: 1, invitadoId: 1, categoria: 1 },
+  { unique: true, sparse: true }
+);
 
 export default mongoose.model('Resultado', resultadoSchema);

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -2,19 +2,84 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../api';
 
+const CATEGORIAS = [
+  'CHP',
+  'M7DE',
+  'M7VE',
+  'PDE',
+  'PVE',
+  '6DE',
+  '6VE',
+  '5DE',
+  '5VE',
+  '4DE',
+  '4VE',
+  'JDE',
+  'JVE',
+  'MDE',
+  'MVE',
+  'PDT',
+  'PVT',
+  '6DT',
+  '6VT',
+  '5DT',
+  '5VT',
+  '4DT',
+  '4VT',
+  'JDI',
+  'JVI',
+  'MDI',
+  'MVI',
+  'PDF',
+  'PVF',
+  '6DF',
+  '6VF',
+  '5DF',
+  '5VF',
+  '4DF',
+  '4VF',
+  'JDF',
+  'JVF',
+  'MDF',
+  'MVF'
+];
+
 export default function ResultadosCompetencia() {
   const { id } = useParams();
   const [resultados, setResultados] = useState([]);
+  const [patinadores, setPatinadores] = useState([]);
+  const [externos, setExternos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [archivo, setArchivo] = useState(null);
+
+  const [categoria, setCategoria] = useState('');
+  const [posicion, setPosicion] = useState('');
+  const [tiempoMs, setTiempoMs] = useState('');
+  const [puntos, setPuntos] = useState('');
+  const [dorsal, setDorsal] = useState('');
+  const [tipo, setTipo] = useState('local');
+  const [patinadorId, setPatinadorId] = useState('');
+  const [externoSeleccionado, setExternoSeleccionado] = useState('');
+  const [invitado, setInvitado] = useState({
+    primerNombre: '',
+    segundoNombre: '',
+    apellido: '',
+    club: ''
+  });
   const rol = localStorage.getItem('rol');
 
   useEffect(() => {
     const cargar = async () => {
       try {
-        const res = await api.get(`/competitions/${id}/resultados`);
-        setResultados(res.data);
+        const [resRes, resPat, resExt] = await Promise.all([
+          api.get(`/competitions/${id}/resultados`),
+          api.get('/patinadores'),
+          api.get('/patinadores-externos')
+        ]);
+        setResultados(resRes.data);
+        setPatinadores(resPat.data);
+        setExternos(resExt.data);
       } catch (err) {
         console.error(err);
         setError('Error al cargar resultados');
@@ -24,6 +89,59 @@ export default function ResultadosCompetencia() {
     };
     cargar();
   }, [id]);
+
+  const handleSelectExterno = (id) => {
+    setExternoSeleccionado(id);
+    const ext = externos.find((e) => e._id === id);
+    if (ext) {
+      setInvitado({
+        primerNombre: ext.primerNombre,
+        segundoNombre: ext.segundoNombre || '',
+        apellido: ext.apellido,
+        club: ext.club
+      });
+    } else {
+      setInvitado({ primerNombre: '', segundoNombre: '', apellido: '', club: '' });
+    }
+  };
+
+  const agregarManual = async (e) => {
+    e.preventDefault();
+    try {
+      const payload = { categoria, posicion, tiempoMs, puntos, dorsal };
+      if (tipo === 'local') {
+        if (!patinadorId) {
+          alert('Seleccione un patinador');
+          return;
+        }
+        payload.patinadorId = patinadorId;
+      } else {
+        if (!invitado.primerNombre || !invitado.apellido || !invitado.club) {
+          alert('Complete los datos del patinador externo');
+          return;
+        }
+        payload.invitado = invitado;
+      }
+      await api.post(`/competitions/${id}/resultados/manual`, payload);
+      const [resRes, resExt] = await Promise.all([
+        api.get(`/competitions/${id}/resultados`),
+        api.get('/patinadores-externos')
+      ]);
+      setResultados(resRes.data);
+      setExternos(resExt.data);
+      setCategoria('');
+      setPosicion('');
+      setTiempoMs('');
+      setPuntos('');
+      setDorsal('');
+      setPatinadorId('');
+      setExternoSeleccionado('');
+      setInvitado({ primerNombre: '', segundoNombre: '', apellido: '', club: '' });
+    } catch (err) {
+      console.error(err);
+      alert('Error al guardar resultado');
+    }
+  };
   const importar = async (e) => {
     e.preventDefault();
     if (!archivo) return;
@@ -49,23 +167,192 @@ export default function ResultadosCompetencia() {
     <div className="container mt-3">
       <h2>Resultados</h2>
       {rol === 'Delegado' && (
-        <form onSubmit={importar} className="mb-3">
-          <div className="input-group">
-            <input
-              type="file"
-              accept="application/pdf"
-              className="form-control"
-              onChange={(e) => setArchivo(e.target.files[0])}
-            />
-            <button
-              className="btn btn-primary"
-              type="submit"
-              disabled={!archivo}
-            >
-              Importar PDF
-            </button>
-          </div>
-        </form>
+        <>
+          <form onSubmit={importar} className="mb-3">
+            <div className="input-group">
+              <input
+                type="file"
+                accept="application/pdf"
+                className="form-control"
+                onChange={(e) => setArchivo(e.target.files[0])}
+              />
+              <button
+                className="btn btn-primary"
+                type="submit"
+                disabled={!archivo}
+              >
+                Importar PDF
+              </button>
+            </div>
+          </form>
+          <form onSubmit={agregarManual} className="mb-3">
+            <div className="row g-2 align-items-end">
+              <div className="col-md-2">
+                <label className="form-label">Categoría</label>
+                <select
+                  className="form-select"
+                  value={categoria}
+                  onChange={(e) => setCategoria(e.target.value)}
+                  required
+                >
+                  <option value="">Seleccione</option>
+                  {CATEGORIAS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="col-md-2">
+                <label className="form-label">Posición</label>
+                <input
+                  type="number"
+                  className="form-control"
+                  value={posicion}
+                  onChange={(e) => setPosicion(e.target.value)}
+                />
+              </div>
+              <div className="col-md-2">
+                <label className="form-label">Tiempo (ms)</label>
+                <input
+                  type="number"
+                  className="form-control"
+                  value={tiempoMs}
+                  onChange={(e) => setTiempoMs(e.target.value)}
+                />
+              </div>
+              <div className="col-md-2">
+                <label className="form-label">Puntos</label>
+                <input
+                  type="number"
+                  className="form-control"
+                  value={puntos}
+                  onChange={(e) => setPuntos(e.target.value)}
+                />
+              </div>
+              <div className="col-md-2">
+                <label className="form-label">Dorsal</label>
+                <input
+                  className="form-control"
+                  value={dorsal}
+                  onChange={(e) => setDorsal(e.target.value)}
+                />
+              </div>
+              <div className="col-12 mt-2">
+                <div className="form-check form-check-inline">
+                  <input
+                    className="form-check-input"
+                    type="radio"
+                    name="tipo"
+                    id="tipoLocal"
+                    value="local"
+                    checked={tipo === 'local'}
+                    onChange={() => setTipo('local')}
+                  />
+                  <label className="form-check-label" htmlFor="tipoLocal">
+                    Club GR
+                  </label>
+                </div>
+                <div className="form-check form-check-inline">
+                  <input
+                    className="form-check-input"
+                    type="radio"
+                    name="tipo"
+                    id="tipoExterno"
+                    value="externo"
+                    checked={tipo === 'externo'}
+                    onChange={() => setTipo('externo')}
+                  />
+                  <label className="form-check-label" htmlFor="tipoExterno">
+                    Otro club
+                  </label>
+                </div>
+              </div>
+              {tipo === 'local' ? (
+                <div className="col-12 mt-2">
+                  <select
+                    className="form-select"
+                    value={patinadorId}
+                    onChange={(e) => setPatinadorId(e.target.value)}
+                    required
+                  >
+                    <option value="">Seleccione patinador</option>
+                    {patinadores.map((p) => (
+                      <option key={p._id} value={p._id}>
+                        {`${p.primerNombre} ${p.segundoNombre || ''} ${p.apellido}`.trim()}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <div className="col-12 mt-2">
+                  <select
+                    className="form-select mb-2"
+                    value={externoSeleccionado}
+                    onChange={(e) => handleSelectExterno(e.target.value)}
+                  >
+                    <option value="">Nuevo patinador</option>
+                    {externos.map((ex) => (
+                      <option key={ex._id} value={ex._id}>
+                        {`${ex.primerNombre} ${ex.segundoNombre || ''} ${ex.apellido} - ${ex.club}`.trim()}
+                      </option>
+                    ))}
+                  </select>
+                  <div className="row g-2">
+                    <div className="col-md-3">
+                      <input
+                        className="form-control"
+                        placeholder="Primer nombre"
+                        value={invitado.primerNombre}
+                        onChange={(e) =>
+                          setInvitado({ ...invitado, primerNombre: e.target.value })
+                        }
+                        required
+                      />
+                    </div>
+                    <div className="col-md-3">
+                      <input
+                        className="form-control"
+                        placeholder="Segundo nombre"
+                        value={invitado.segundoNombre}
+                        onChange={(e) =>
+                          setInvitado({ ...invitado, segundoNombre: e.target.value })
+                        }
+                      />
+                    </div>
+                    <div className="col-md-3">
+                      <input
+                        className="form-control"
+                        placeholder="Apellido"
+                        value={invitado.apellido}
+                        onChange={(e) =>
+                          setInvitado({ ...invitado, apellido: e.target.value })
+                        }
+                        required
+                      />
+                    </div>
+                    <div className="col-md-3">
+                      <input
+                        className="form-control"
+                        placeholder="Club"
+                        value={invitado.club}
+                        onChange={(e) =>
+                          setInvitado({ ...invitado, club: e.target.value })
+                        }
+                        required
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+              <div className="col-12 mt-3">
+                <button className="btn btn-success" type="submit">
+                  Agregar
+                </button>
+              </div>
+            </div>
+          </form>
+        </>
       )}
       {resultados.length === 0 ? (
         <p>No hay resultados cargados.</p>
@@ -87,7 +374,11 @@ export default function ResultadosCompetencia() {
                 <tr key={r._id}>
                   <td>{r.categoria}</td>
                   <td>{r.posicion}</td>
-                  <td>{`${r.deportistaId?.primerNombre || ''} ${r.deportistaId?.segundoNombre || ''} ${r.deportistaId?.apellido || ''}`.trim()}</td>
+                  <td>
+                    {r.deportistaId
+                      ? `${r.deportistaId?.primerNombre || ''} ${r.deportistaId?.segundoNombre || ''} ${r.deportistaId?.apellido || ''}`.trim()
+                      : `${r.invitadoId?.primerNombre || ''} ${r.invitadoId?.segundoNombre || ''} ${r.invitadoId?.apellido || ''}`.trim()}
+                  </td>
                   <td>{r.tiempoMs}</td>
                   <td>{r.puntos}</td>
                   <td>{r.dorsal}</td>


### PR DESCRIPTION
## Summary
- add model for external skaters and store them on manual score entry
- allow results to reference either local or external skaters
- enable delegated users to manually add results by category from the UI

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a624fd798c8320807dd02a9822b96f