### PR TITLE
Remove manual time entry and auto-fill dorsal

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -679,7 +679,7 @@ app.post(
   protegerRuta,
   permitirRol('Delegado'),
   async (req, res) => {
-    const { categoria, posicion, tiempoMs, puntos, dorsal, patinadorId, invitado } =
+    const { categoria, posicion, puntos, dorsal, patinadorId, invitado } =
       req.body;
     try {
       const competencia = await Competencia.findById(req.params.id);
@@ -719,7 +719,7 @@ app.post(
           .json({ mensaje: 'Debe proporcionar patinadorId o datos de invitado' });
       }
 
-      const actualizacion = { posicion, tiempoMs, puntos, dorsal };
+      const actualizacion = { posicion, puntos, dorsal };
 
       const resultado = await Resultado.findOneAndUpdate(filtro, actualizacion, {
         upsert: true,

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -55,7 +55,6 @@ export default function ResultadosCompetencia() {
 
   const [categoria, setCategoria] = useState('');
   const [posicion, setPosicion] = useState('');
-  const [tiempoMs, setTiempoMs] = useState('');
   const [puntos, setPuntos] = useState('');
   const [dorsal, setDorsal] = useState('');
   const [tipo, setTipo] = useState('local');
@@ -108,7 +107,7 @@ export default function ResultadosCompetencia() {
   const agregarManual = async (e) => {
     e.preventDefault();
     try {
-      const payload = { categoria, posicion, tiempoMs, puntos, dorsal };
+      const payload = { categoria, posicion, puntos, dorsal };
       if (tipo === 'local') {
         if (!patinadorId) {
           alert('Seleccione un patinador');
@@ -131,7 +130,6 @@ export default function ResultadosCompetencia() {
       setExternos(resExt.data);
       setCategoria('');
       setPosicion('');
-      setTiempoMs('');
       setPuntos('');
       setDorsal('');
       setPatinadorId('');
@@ -213,15 +211,6 @@ export default function ResultadosCompetencia() {
                 />
               </div>
               <div className="col-md-2">
-                <label className="form-label">Tiempo (ms)</label>
-                <input
-                  type="number"
-                  className="form-control"
-                  value={tiempoMs}
-                  onChange={(e) => setTiempoMs(e.target.value)}
-                />
-              </div>
-              <div className="col-md-2">
                 <label className="form-label">Puntos</label>
                 <input
                   type="number"
@@ -231,11 +220,12 @@ export default function ResultadosCompetencia() {
                 />
               </div>
               <div className="col-md-2">
-                <label className="form-label">Dorsal</label>
+                <label className="form-label">N° de patinador</label>
                 <input
                   className="form-control"
                   value={dorsal}
                   onChange={(e) => setDorsal(e.target.value)}
+                  readOnly={tipo === 'local'}
                 />
               </div>
               <div className="col-12 mt-2">
@@ -273,7 +263,13 @@ export default function ResultadosCompetencia() {
                   <select
                     className="form-select"
                     value={patinadorId}
-                    onChange={(e) => setPatinadorId(e.target.value)}
+                    onChange={(e) => {
+                      setPatinadorId(e.target.value);
+                      const seleccionado = patinadores.find(
+                        (p) => p._id === e.target.value
+                      );
+                      setDorsal(seleccionado ? seleccionado.numeroCorredor : '');
+                    }}
                     required
                   >
                     <option value="">Seleccione patinador</option>
@@ -366,7 +362,7 @@ export default function ResultadosCompetencia() {
                 <th>Nombre</th>
                 <th>Tiempo (ms)</th>
                 <th>Puntos</th>
-                <th>Dorsal</th>
+                <th>N° de patinador</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- drop tiempo field from manual results entry
- auto-fill dorsal for General Rodríguez skaters and rename dorsal header

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62b2d54b08320adda10d3e5c3fa1d