### PR TITLE
Filtrar patinadores por categoría al cargar resultados

### DIFF
--- a/backend-auth/models/PatinadorExterno.js
+++ b/backend-auth/models/PatinadorExterno.js
@@ -5,7 +5,8 @@ const patinadorExternoSchema = new mongoose.Schema(
     primerNombre: { type: String, required: true },
     segundoNombre: { type: String },
     apellido: { type: String, required: true },
-    club: { type: String, required: true }
+    club: { type: String, required: true },
+    categoria: { type: String, required: true }
   },
   { timestamps: true }
 );

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -354,7 +354,14 @@ app.get('/api/patinadores', async (req, res) => {
 
 app.get('/api/patinadores-externos', protegerRuta, async (req, res) => {
   try {
-    const externos = await PatinadorExterno.find().sort({ apellido: 1, primerNombre: 1 });
+    const filtro = {};
+    if (req.query.categoria) {
+      filtro.categoria = req.query.categoria;
+    }
+    const externos = await PatinadorExterno.find(filtro).sort({
+      apellido: 1,
+      primerNombre: 1
+    });
     res.json(externos);
   } catch (err) {
     console.error(err);
@@ -709,8 +716,12 @@ app.post(
             primerNombre,
             segundoNombre,
             apellido,
-            club
+            club,
+            categoria
           });
+        } else if (ext.categoria !== categoria) {
+          ext.categoria = categoria;
+          await ext.save();
         }
         filtro.invitadoId = ext._id;
       } else {

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -69,6 +69,19 @@ export default function ResultadosCompetencia() {
   const rol = localStorage.getItem('rol');
 
   useEffect(() => {
+    setPatinadorId('');
+    setExternoSeleccionado('');
+  }, [categoria]);
+
+  const patinadoresFiltrados = categoria
+    ? patinadores.filter((p) => p.categoria === categoria)
+    : patinadores;
+
+  const externosFiltrados = categoria
+    ? externos.filter((e) => e.categoria === categoria)
+    : externos;
+
+  useEffect(() => {
     const cargar = async () => {
       try {
         const [resRes, resPat, resExt] = await Promise.all([
@@ -265,7 +278,7 @@ export default function ResultadosCompetencia() {
                     value={patinadorId}
                     onChange={(e) => {
                       setPatinadorId(e.target.value);
-                      const seleccionado = patinadores.find(
+                      const seleccionado = patinadoresFiltrados.find(
                         (p) => p._id === e.target.value
                       );
                       setDorsal(seleccionado ? seleccionado.numeroCorredor : '');
@@ -273,7 +286,7 @@ export default function ResultadosCompetencia() {
                     required
                   >
                     <option value="">Seleccione patinador</option>
-                    {patinadores.map((p) => (
+                    {patinadoresFiltrados.map((p) => (
                       <option key={p._id} value={p._id}>
                         {`${p.primerNombre} ${p.segundoNombre || ''} ${p.apellido}`.trim()}
                       </option>
@@ -288,7 +301,7 @@ export default function ResultadosCompetencia() {
                     onChange={(e) => handleSelectExterno(e.target.value)}
                   >
                     <option value="">Nuevo patinador</option>
-                    {externos.map((ex) => (
+                    {externosFiltrados.map((ex) => (
                       <option key={ex._id} value={ex._id}>
                         {`${ex.primerNombre} ${ex.segundoNombre || ''} ${ex.apellido} - ${ex.club}`.trim()}
                       </option>


### PR DESCRIPTION
## Summary
- Agrega campo `categoria` al modelo de patinadores externos.
- Permite filtrar patinadores externos por categoría desde la API.
- Filtra en el frontend los patinadores (locales y externos) según la categoría seleccionada.

## Testing
- `npm test` (backend)
- `npm test` *(falla: Missing script "test" en frontend)*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a647158ad4832092851ba468e42b96