### PR TITLE
Remove tiempo field from results

### DIFF
--- a/backend-auth/models/Resultado.js
+++ b/backend-auth/models/Resultado.js
@@ -24,7 +24,6 @@ const resultadoSchema = new mongoose.Schema(
     categoria: { type: String, required: true },
     clubId: { type: mongoose.Schema.Types.ObjectId, ref: 'Club' },
     posicion: Number,
-    tiempoMs: Number,
     puntos: Number,
     dorsal: String,
     fuenteImportacion: {

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -666,7 +666,6 @@ app.post(
           },
           {
             posicion: fila.posicion,
-            tiempoMs: fila.tiempoMs,
             puntos: fila.puntos,
             dorsal: fila.dorsal,
             fuenteImportacion: {

--- a/backend-auth/utils/parseResultadosPdf.js
+++ b/backend-auth/utils/parseResultadosPdf.js
@@ -1,14 +1,5 @@
 import pdf from 'pdf-parse/lib/pdf-parse.js';
 
-function tiempoTextoAMs(t) {
-  const match = t.match(/(?:(\d+):)?(\d{1,2})(?:\.(\d{1,3}))?/);
-  if (!match) return null;
-  const min = parseInt(match[1] || '0', 10);
-  const sec = parseInt(match[2] || '0', 10);
-  const ms = parseInt((match[3] || '').padEnd(3, '0'), 10);
-  return (min * 60 + sec) * 1000 + ms;
-}
-
 export default async function parseResultadosPdf(buffer) {
   const data = await pdf(buffer);
   const lines = data.text
@@ -27,15 +18,14 @@ export default async function parseResultadosPdf(buffer) {
       const pos = parseInt(parts[0], 10);
       const dorsal = parts[1];
       const puntos = parseFloat(parts[parts.length - 1]);
-      const tiempoStr = parts[parts.length - 2];
-      const categoria = parts[parts.length - 3];
-      const nombre = parts.slice(2, parts.length - 3).join(' ');
+      const trailing = parts.length > 5 ? 3 : 2;
+      const categoria = parts[parts.length - trailing];
+      const nombre = parts.slice(2, parts.length - trailing).join(' ');
       return {
         posicion: pos,
         dorsal,
         nombre,
         categoria,
-        tiempoMs: tiempoTextoAMs(tiempoStr),
         puntos
       };
     })

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -373,7 +373,6 @@ export default function ResultadosCompetencia() {
                 <th>Categoría</th>
                 <th>Posición</th>
                 <th>Nombre</th>
-                <th>Tiempo (ms)</th>
                 <th>Puntos</th>
                 <th>N° de patinador</th>
               </tr>
@@ -388,7 +387,6 @@ export default function ResultadosCompetencia() {
                       ? `${r.deportistaId?.primerNombre || ''} ${r.deportistaId?.segundoNombre || ''} ${r.deportistaId?.apellido || ''}`.trim()
                       : `${r.invitadoId?.primerNombre || ''} ${r.invitadoId?.segundoNombre || ''} ${r.invitadoId?.apellido || ''}`.trim()}
                   </td>
-                  <td>{r.tiempoMs}</td>
                   <td>{r.puntos}</td>
                   <td>{r.dorsal}</td>
                 </tr>


### PR DESCRIPTION
## Summary
- Drop tiempoMs from result parsing and schema
- Exclude tiempo column from API import and frontend table

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a64e7bba10832099bef86ce4aeb905