### PR TITLE
fix: remove obsolete index causing external skater creation failures

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -47,7 +47,11 @@ const MONGODB_URI =
 
 mongoose
   .connect(MONGODB_URI)
-  .then(() => console.log('MongoDB conectado'))
+  .then(async () => {
+    console.log('MongoDB conectado');
+    // Ensure outdated indexes like `numeroCorredor_1` are removed
+    await PatinadorExterno.syncIndexes();
+  })
   .catch((err) => console.error('Error conectando a MongoDB:', err.message));
 
 const app = express();


### PR DESCRIPTION
## Summary
- ensure MongoDB removes stale `numeroCorredor_1` index for external skaters
- prevent duplicate key errors when saving external results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6eadc505c83209912120d70863752