### PR TITLE
Store external skater number

### DIFF
--- a/backend-auth/models/PatinadorExterno.js
+++ b/backend-auth/models/PatinadorExterno.js
@@ -6,7 +6,8 @@ const patinadorExternoSchema = new mongoose.Schema(
     segundoNombre: { type: String },
     apellido: { type: String, required: true },
     club: { type: String, required: true },
-    categoria: { type: String, required: true }
+    categoria: { type: String, required: true },
+    numeroCorredor: { type: Number }
   },
   { timestamps: true }
 );

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -49,7 +49,7 @@ mongoose
   .connect(MONGODB_URI)
   .then(async () => {
     console.log('MongoDB conectado');
-    // Ensure outdated indexes like `numeroCorredor_1` are removed
+    // Mantener los índices sincronizados con el esquema actual
     await PatinadorExterno.syncIndexes();
   })
   .catch((err) => console.error('Error conectando a MongoDB:', err.message));
@@ -748,11 +748,20 @@ app.post(
             segundoNombre,
             apellido,
             club,
-            categoria
+            categoria,
+            numeroCorredor: dorsal
           });
-        } else if (ext.categoria !== categoria) {
-          ext.categoria = categoria;
-          await ext.save();
+        } else {
+          let actualizado = false;
+          if (ext.categoria !== categoria) {
+            ext.categoria = categoria;
+            actualizado = true;
+          }
+          if (dorsal && ext.numeroCorredor !== Number(dorsal)) {
+            ext.numeroCorredor = Number(dorsal);
+            actualizado = true;
+          }
+          if (actualizado) await ext.save();
         }
         filtro.invitadoId = ext._id;
       } else {

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -111,8 +111,10 @@ export default function ResultadosCompetencia() {
         apellido: ext.apellido,
         club: ext.club
       });
+      setDorsal(ext.numeroCorredor || '');
     } else {
       setInvitado({ primerNombre: '', segundoNombre: '', apellido: '', club: '' });
+      setDorsal('');
     }
   };
 


### PR DESCRIPTION
## Summary
- add `numeroCorredor` to external skater schema
- persist dorsal to external skaters and sync indexes
- autofill skater number when selecting an external athlete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6f0d8bfdc83208ffc82d5338780c4