### PR TITLE
Keep selected category when adding scores

### DIFF
--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -142,7 +142,6 @@ export default function ResultadosCompetencia() {
       ]);
       setResultados(resRes.data);
       setExternos(resExt.data);
-      setCategoria('');
       setPuntos('');
       setDorsal('');
       setPatinadorId('');


### PR DESCRIPTION
## Summary
- Prevent category reset after manually saving competition results so selection persists until user changes it

## Testing
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4c99b8c8320bf9220da27f2195f