### PR TITLE
feat: allow creating tournaments

### DIFF
--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -6,6 +6,10 @@ export default function Torneos() {
   const [torneos, setTorneos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [nombre, setNombre] = useState('');
+  const [fechaInicio, setFechaInicio] = useState('');
+  const [fechaFin, setFechaFin] = useState('');
+  const rol = localStorage.getItem('rol');
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -23,12 +27,64 @@ export default function Torneos() {
     cargar();
   }, []);
 
+  const crearTorneo = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/tournaments', { nombre, fechaInicio, fechaFin });
+      setNombre('');
+      setFechaInicio('');
+      setFechaFin('');
+      const res = await api.get('/tournaments');
+      setTorneos(res.data);
+    } catch (err) {
+      console.error(err);
+      alert('Error al crear torneo');
+    }
+  };
+
   if (loading) return <div className="container mt-3">Cargando torneos...</div>;
   if (error) return <div className="container mt-3 text-danger">{error}</div>;
 
   return (
     <div className="container mt-3">
       <h2>Torneos</h2>
+      {rol === 'Delegado' && (
+        <form onSubmit={crearTorneo} className="row g-2 mb-3">
+          <div className="col-md-4">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Nombre"
+              value={nombre}
+              onChange={(e) => setNombre(e.target.value)}
+              required
+            />
+          </div>
+          <div className="col-md-3">
+            <input
+              type="date"
+              className="form-control"
+              value={fechaInicio}
+              onChange={(e) => setFechaInicio(e.target.value)}
+              required
+            />
+          </div>
+          <div className="col-md-3">
+            <input
+              type="date"
+              className="form-control"
+              value={fechaFin}
+              onChange={(e) => setFechaFin(e.target.value)}
+              required
+            />
+          </div>
+          <div className="col-md-2">
+            <button type="submit" className="btn btn-primary w-100">
+              Crear
+            </button>
+          </div>
+        </form>
+      )}
       {torneos.length === 0 ? (
         <p>No hay torneos disponibles.</p>
       ) : (


### PR DESCRIPTION
## Summary
- allow delegated users to create tournaments from tournament page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a752db09188320a5161c34f6a4c14d