### PR TITLE
feat: add modern styles and dark mode

### DIFF
--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -10,6 +10,7 @@ export default function Navbar() {
   const foto = localStorage.getItem('foto');
   const isLoggedIn = localStorage.getItem('token');
   const [unread, setUnread] = useState(0);
+  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
 
   useEffect(() => {
     let interval;
@@ -32,6 +33,11 @@ export default function Navbar() {
       window.removeEventListener('notificationsUpdated', cargar);
     };
   }, [isLoggedIn]);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark-mode', darkMode);
+    localStorage.setItem('darkMode', darkMode);
+  }, [darkMode]);
 
   const handleNavigate = (path) => navigate(path);
 
@@ -94,7 +100,7 @@ export default function Navbar() {
     : [];
 
   return (
-    <nav className="navbar navbar-expand-lg navbar-light bg-light">
+    <nav className="navbar navbar-expand-lg navbar-dark">
       <div className="container">
         <a
           className="navbar-brand d-flex align-items-center"
@@ -161,43 +167,51 @@ export default function Navbar() {
               )
             ))}
           </ul>
-          {isLoggedIn && (
-            <div className="d-flex align-items-center gap-2 ms-auto">
-              <div className="position-relative me-2">
-                <i
-                  className="bi bi-bell"
-                  style={{ fontSize: '1.5rem', color: unread > 0 ? 'red' : 'gray', cursor: 'pointer' }}
-                  onClick={() => handleNavigate('/notificaciones')}
-                ></i>
-                {unread > 0 && (
-                  <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
-                    {unread}
-                  </span>
-                )}
-              </div>
-              <div className="position-relative">
-                <img
-                  src={foto || '/default-user.png'}
-                  alt="Foto perfil"
-                  width="40"
-                  height="40"
-                  className="rounded-circle"
-                  style={{ objectFit: 'cover', cursor: foto?.includes('googleusercontent') ? 'default' : 'pointer' }}
-                  onClick={!foto?.includes('googleusercontent') ? triggerFileSelect : undefined}
-                />
-                {!foto?.includes('googleusercontent') && (
-                  <input
-                    type="file"
-                    accept="image/*"
-                    ref={fileInputRef}
-                    style={{ display: 'none' }}
-                    onChange={handleFileChange}
+          <div className="d-flex align-items-center gap-2 ms-auto">
+            <button
+              className="btn btn-sm btn-outline-light"
+              onClick={() => setDarkMode(!darkMode)}
+            >
+              <i className={`bi ${darkMode ? 'bi-sun' : 'bi-moon'}`}></i>
+            </button>
+            {isLoggedIn && (
+              <>
+                <div className="position-relative me-2">
+                  <i
+                    className="bi bi-bell"
+                    style={{ fontSize: '1.5rem', color: unread > 0 ? 'red' : 'gray', cursor: 'pointer' }}
+                    onClick={() => handleNavigate('/notificaciones')}
+                  ></i>
+                  {unread > 0 && (
+                    <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                      {unread}
+                    </span>
+                  )}
+                </div>
+                <div className="position-relative">
+                  <img
+                    src={foto || '/default-user.png'}
+                    alt="Foto perfil"
+                    width="40"
+                    height="40"
+                    className="rounded-circle"
+                    style={{ objectFit: 'cover', cursor: foto?.includes('googleusercontent') ? 'default' : 'pointer' }}
+                    onClick={!foto?.includes('googleusercontent') ? triggerFileSelect : undefined}
                   />
-                )}
-              </div>
-              <LogoutButton />
-            </div>
-          )}
+                  {!foto?.includes('googleusercontent') && (
+                    <input
+                      type="file"
+                      accept="image/*"
+                      ref={fileInputRef}
+                      style={{ display: 'none' }}
+                      onChange={handleFileChange}
+                    />
+                  )}
+                </div>
+                <LogoutButton />
+              </>
+            )}
+          </div>
         </div>
       </div>
     </nav>

--- a/frontend-auth/src/main.jsx
+++ b/frontend-auth/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import './styles.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -1,0 +1,59 @@
+:root {
+  --primary-color: #007bff;
+  --secondary-color: #28a745;
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --card-bg: #ffffff;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.navbar {
+  background-color: var(--primary-color) !important;
+  transition: background-color 0.3s ease;
+}
+
+.navbar .nav-link,
+.navbar-brand {
+  color: var(--bg-color) !important;
+}
+
+.dropdown-menu {
+  background-color: var(--card-bg);
+}
+
+.dropdown-item {
+  color: var(--text-color);
+}
+
+.card {
+  background-color: var(--card-bg);
+  border: none;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.btn-primary {
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+}
+
+body.dark-mode {
+  --bg-color: #000000;
+  --text-color: #ffffff;
+  --card-bg: #1e1e1e;
+}
+
+body.dark-mode .navbar {
+  background-color: #000000 !important;
+}
+
+body.dark-mode .btn-primary {
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+}


### PR DESCRIPTION
## Summary
- implement global color scheme using blue, green, black, and white
- add dark mode toggle in the navigation bar
- apply modern styling to navigation and cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a761d26d7c83208753542673ca1d6d