### PR TITLE
Estilo de tarjetas de noticias

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -73,16 +73,24 @@ export default function Home() {
       )}
       <h1 className="mb-4">Noticias</h1>
       {news.map((n) => (
-        <div className="card mb-3" key={n._id}>
-          {n.imagen && <img src={n.imagen} className="card-img-top" alt="imagen noticia" />}
-          <div className="card-body">
-            <h5 className="card-title">{n.titulo}</h5>
-            <p className="card-text">{n.contenido}</p>
-            <p className="card-text">
-              <small className="text-muted">
-                {n.autor} - {new Date(n.fecha).toLocaleDateString()}
-              </small>
-            </p>
+        <div className="card mb-3 news-card" key={n._id}>
+          <div className="news-title">
+            <h5>{n.titulo}</h5>
+          </div>
+          <div className="news-content">
+            {n.imagen && (
+              <div className="news-image">
+                <img src={n.imagen} alt="imagen noticia" />
+              </div>
+            )}
+            <div className="news-text">
+              <p>{n.contenido}</p>
+            </div>
+          </div>
+          <div className="news-footer">
+            <small className="text-muted">
+              {n.autor} - {new Date(n.fecha).toLocaleDateString()}
+            </small>
           </div>
         </div>
       ))}

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -57,3 +57,45 @@ body.dark-mode .btn-primary {
   background-color: var(--secondary-color);
   border-color: var(--secondary-color);
 }
+
+/* News card styles */
+.news-card {
+  background-color: #fff;
+}
+
+.news-card .news-title {
+  background-color: #000;
+  color: #fff;
+  padding: 0.5rem 1rem;
+}
+
+.news-card .news-title h5 {
+  margin: 0;
+}
+
+.news-card .news-content {
+  display: flex;
+}
+
+.news-card .news-image,
+.news-card .news-text {
+  flex: 1;
+}
+
+.news-card .news-image img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.news-card .news-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+}
+
+.news-card .news-footer {
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- Formato estructurado para tarjetas de noticias con título negro, contenido en dos columnas e información del autor.
- Estilos CSS dedicados que distribuyen imagen y texto en 50/50 y centran el contenido.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a79a03df30832086e4340be15ae920