### PR TITLE
feat: space news images on small screens

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -99,3 +99,13 @@ body.dark-mode .btn-primary {
 .news-card .news-footer {
   padding: 0.5rem 1rem;
 }
+
+@media (max-width: 576px) {
+  .news-card .news-content {
+    flex-direction: column;
+  }
+
+  .news-card .news-image {
+    margin-top: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- stack news card content vertically and separate image from title on small displays

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7b32d0dc48320b459c9f47617a193