### PR TITLE
feat: show skater cards in responsive grid

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -45,30 +45,34 @@ export default function Home() {
       {localStorage.getItem('token') && tienePatinadores && (
         <>
           <h2 className="mb-4">Patinadores Asociados</h2>
-          {patinadores.map((p) => (
-            <div className="card mb-3" key={p._id}>
-              <div className="row g-0">
-                {p.foto && (
-                  <div className="col-md-4">
-                    <img src={p.foto} className="img-fluid rounded-start" alt="foto patinador" />
-                  </div>
-                )}
-                <div className="col-md-8">
-                  <div className="card-body">
-                    <h5 className="card-title">
-                      {p.primerNombre} {p.apellido}
-                    </h5>
-                    <p className="card-text">
-                      <strong>Categoría:</strong> {p.categoria}
-                    </p>
-                    <p className="card-text">
-                      <strong>Edad:</strong> {p.edad}
-                    </p>
+          <div className="row">
+            {patinadores.map((p) => (
+              <div className="col-12 col-lg-4 mb-3" key={p._id}>
+                <div className="card h-100">
+                  <div className="row g-0">
+                    {p.foto && (
+                      <div className="col-md-4">
+                        <img src={p.foto} className="img-fluid rounded-start" alt="foto patinador" />
+                      </div>
+                    )}
+                    <div className="col-md-8">
+                      <div className="card-body">
+                        <h5 className="card-title">
+                          {p.primerNombre} {p.apellido}
+                        </h5>
+                        <p className="card-text">
+                          <strong>Categoría:</strong> {p.categoria}
+                        </p>
+                        <p className="card-text">
+                          <strong>Edad:</strong> {p.edad}
+                        </p>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </>
       )}
       <h1 className="mb-4">Noticias</h1>


### PR DESCRIPTION
## Summary
- display skater cards in responsive grid with three columns on large screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a83c1f52c483208030d08da0ebdfc3