### PR TITLE
style: align patinador card image and text

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -126,20 +126,32 @@ body.dark-mode .btn-primary {
 /* Patinador card styles */
 .patinador-card {
   width: 60vw;
-  height: 100vh;
   margin: 0 auto;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  flex-direction: row;
   align-items: center;
-  text-align: center;
+  text-align: left;
 }
 
 .patinador-card img {
-  width: 100%;
-  height: auto;
-  max-height: 50%;
+  width: 40%;
   object-fit: cover;
+}
+
+.patinador-card .card-body {
+  flex: 1;
+  padding: 1rem;
+}
+
+@media (max-width: 576px) {
+  .patinador-card {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .patinador-card img {
+    width: 100%;
+  }
 }
 
 .patinador-card .card-title {


### PR DESCRIPTION
## Summary
- Display patinador card image beside text, aligned to the left
- Add responsive layout for patinador cards on small screens

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8427a02688320b882b74436cce105