### PR TITLE
Add spacing between cards on home page

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -63,11 +63,10 @@ body.dark-mode .btn-primary {
   background-color: #fff;
   width: 60vw;
   height: 100vh;
-  margin: 0 auto;
+  margin: 0 auto 1.5rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-bottom: 0 !important;
 }
 
 .news-card .news-title {
@@ -126,7 +125,7 @@ body.dark-mode .btn-primary {
 /* Patinador card styles */
 .patinador-card {
   width: 60vw;
-  margin: 0 auto;
+  margin: 0 auto 1.5rem;
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Summary
- add bottom margin to news cards
- add bottom margin to patinador cards

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8441745348320bb2b464b75e642bf