### PR TITLE
Simplify tournament view button text

### DIFF
--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -144,7 +144,7 @@ export default function Torneos() {
                   className="btn btn-primary btn-sm"
                   onClick={() => navigate(`/torneos/${t._id}`)}
                 >
-                  Ver Competencias
+                  Ver
                 </button>
                 {rol === 'Delegado' && (
                   <>


### PR DESCRIPTION
## Summary
- Change "Ver Competencias" button label to "Ver" in tournaments page

## Testing
- ⚠️ `npm test` (missing script: "test")
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a89fe5c9f083208ba713ea9ddd6d92