### PR TITLE
Simplify competition button labels

### DIFF
--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -120,7 +120,7 @@ export default function Competencias() {
                       className="btn btn-secondary btn-sm"
                       onClick={() => navigate(`/competencias/${c._id}/lista`)}
                     >
-                      Lista Buena Fe
+                      LBF
                     </button>
                     <button
                       className="btn btn-warning btn-sm"
@@ -140,7 +140,7 @@ export default function Competencias() {
                   className="btn btn-info btn-sm"
                   onClick={() => navigate(`/competencias/${c._id}/resultados`)}
                 >
-                  Ver Resultados
+                  VER
                 </button>
               </div>
             </li>


### PR DESCRIPTION
## Summary
- Shorten competition actions for quicker access by renaming **Lista Buena Fe** to **LBF**
- Replace verbose **Ver Resultados** button with concise **VER** label

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8a21e7c6083208e05929c912e64f0