### PR TITLE
Adjust dark mode background color

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -44,13 +44,13 @@ body {
 }
 
 body.dark-mode {
-  --bg-color: #1a1a1a;
+  --bg-color: #2a2a2a;
   --text-color: #ffffff;
   --card-bg: #1e1e1e;
 }
 
 body.dark-mode .navbar {
-  background-color: var(--bg-color) !important;
+  background-color: #1a1a1a !important;
 }
 
 body.dark-mode .navbar .nav-link,


### PR DESCRIPTION
## Summary
- Lighten dark mode background so it appears lighter than the navbar
- Keep navbar darker for better contrast in dark mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a93390eb9c8320a6fc5287c9bc9b19