### PR TITLE
Ensure patinador card text is white in dark mode

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -135,6 +135,7 @@ body.dark-mode .btn-primary {
   flex-direction: row;
   align-items: center;
   text-align: left;
+  color: var(--text-color);
 }
 
 .patinador-card img {
@@ -160,8 +161,10 @@ body.dark-mode .btn-primary {
 
 .patinador-card .card-title {
   font-size: 2rem;
+  color: inherit;
 }
 
 .patinador-card .card-text {
   font-size: 1.5rem;
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- Use theme text color on patinador cards so they render white in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa6bc720d08320a1cf337f2060b3e7