### PR TITLE
Ensure card text switches to white in dark mode

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -36,6 +36,12 @@ body {
   border: none;
   border-radius: 0.5rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  color: var(--text-color);
+}
+
+.card-title,
+.card-text {
+  color: var(--text-color);
 }
 
 .btn-primary {


### PR DESCRIPTION
## Summary
- Make card titles and text use CSS variable so colors flip automatically in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa6f0c2dd483209be74aca236e9e00