### PR TITLE
Add insurance selection to skater records

### DIFF
--- a/backend-auth/models/Patinador.js
+++ b/backend-auth/models/Patinador.js
@@ -19,6 +19,11 @@ const patinadorSchema = new mongoose.Schema(
       enum: ['Escuela', 'Transicion', 'Intermedia', 'Federados'],
       required: true
     },
+    seguro: {
+      type: String,
+      enum: ['S/S', 'SA', 'SD'],
+      default: 'S/S'
+    },
     numeroCorredor: { type: Number, required: true, unique: true },
     categoria: { type: String, required: true },
     fotoRostro: { type: String },

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -324,6 +324,7 @@ app.post(
         telefono,
         sexo,
         nivel,
+        seguro,
         numeroCorredor,
         categoria
       } = req.body;
@@ -345,6 +346,7 @@ app.post(
         telefono,
         sexo,
         nivel,
+        seguro,
         numeroCorredor,
         categoria,
         fotoRostro: fotoRostroFile

--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -23,6 +23,7 @@ export default function CargarPatinador() {
     formData.append('telefono', form.telefono.value);
     formData.append('sexo', form.sexo.value);
     formData.append('nivel', form.nivel.value);
+    formData.append('seguro', form.seguro.value);
     formData.append('numeroCorredor', form.numeroCorredor.value);
     formData.append('categoria', form.categoria.value);
     if (fotoRostro) formData.append('fotoRostro', fotoRostro);
@@ -109,6 +110,14 @@ export default function CargarPatinador() {
               <option value="Transicion">Transición</option>
               <option value="Intermedia">Intermedia</option>
               <option value="Federados">Federados</option>
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Seguro</label>
+            <select className="form-select" name="seguro" defaultValue="S/S">
+              <option value="S/S">S/S</option>
+              <option value="SA">SA</option>
+              <option value="SD">SD</option>
             </select>
           </div>
           <div className="col-md-4">

--- a/frontend-auth/src/pages/EditarPatinador.jsx
+++ b/frontend-auth/src/pages/EditarPatinador.jsx
@@ -38,6 +38,7 @@ export default function EditarPatinador() {
     formData.append('telefono', form.telefono.value);
     formData.append('sexo', form.sexo.value);
     formData.append('nivel', form.nivel.value);
+    formData.append('seguro', form.seguro.value);
     formData.append('numeroCorredor', form.numeroCorredor.value);
     formData.append('categoria', form.categoria.value);
     if (fotoRostro) formData.append('fotoRostro', fotoRostro);
@@ -202,6 +203,18 @@ export default function EditarPatinador() {
               <option value="Transicion">Transición</option>
               <option value="Intermedia">Intermedia</option>
               <option value="Federados">Federados</option>
+            </select>
+          </div>
+          <div className="col-md-4">
+            <label className="form-label">Seguro</label>
+            <select
+              className="form-select"
+              name="seguro"
+              defaultValue={patinador.seguro || 'S/S'}
+            >
+              <option value="S/S">S/S</option>
+              <option value="SA">SA</option>
+              <option value="SD">SD</option>
             </select>
           </div>
           <div className="col-md-4">

--- a/frontend-auth/src/pages/VerPatinador.jsx
+++ b/frontend-auth/src/pages/VerPatinador.jsx
@@ -54,6 +54,7 @@ export default function VerPatinador() {
         <li className="list-group-item">Teléfono: {patinador.telefono}</li>
         <li className="list-group-item">Sexo: {patinador.sexo}</li>
         <li className="list-group-item">Nivel: {patinador.nivel}</li>
+        <li className="list-group-item">Seguro: {patinador.seguro}</li>
         <li className="list-group-item">
           Número de Corredor: {patinador.numeroCorredor}
         </li>


### PR DESCRIPTION
## Summary
- add `seguro` field to Patinador schema with default `S/S`
- allow setting insurance when creating skaters
- expose insurance selection in frontend forms and detail view

## Testing
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68ac5ae0ea6c8320a9ae2d88e4c71dbf