### PR TITLE
Include skater insurance type in Lista Buena Fe Excel

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1071,7 +1071,7 @@ app.get(
       lista.forEach((p, idx) => {
         const row = sheet.getRow(rowNum++);
         row.getCell(1).value = idx + 1;
-        row.getCell(2).value = 'SA';
+        row.getCell(2).value = p.seguro;
         row.getCell(3).value = p.numeroCorredor;
         row.getCell(4).value = `${p.apellido} ${p.primerNombre}`;
         row.getCell(5).value = p.categoria;


### PR DESCRIPTION
## Summary
- use each skater's insurance type when generating the Lista de Buena Fe spreadsheet instead of always inserting "SA"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8ca665dc8320accffc0706671fc7