### PR TITLE
Store and reuse club names for external skaters

### DIFF
--- a/backend-auth/models/Club.js
+++ b/backend-auth/models/Club.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const clubSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true, unique: true, trim: true }
+  },
+  { timestamps: true }
+);
+
+clubSchema.pre('save', function (next) {
+  this.nombre = this.nombre.trim().toUpperCase();
+  next();
+});
+
+export default mongoose.model('Club', clubSchema);

--- a/backend-auth/models/PatinadorExterno.js
+++ b/backend-auth/models/PatinadorExterno.js
@@ -17,4 +17,11 @@ patinadorExternoSchema.index(
   { unique: true }
 );
 
+patinadorExternoSchema.pre('save', function (next) {
+  if (this.club) {
+    this.club = this.club.trim().toUpperCase();
+  }
+  next();
+});
+
 export default mongoose.model('PatinadorExterno', patinadorExternoSchema);

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -49,6 +49,7 @@ export default function ResultadosCompetencia() {
   const [resultados, setResultados] = useState([]);
   const [patinadores, setPatinadores] = useState([]);
   const [externos, setExternos] = useState([]);
+  const [clubes, setClubes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [archivo, setArchivo] = useState(null);
@@ -83,14 +84,16 @@ export default function ResultadosCompetencia() {
   useEffect(() => {
     const cargar = async () => {
       try {
-        const [resRes, resPat, resExt] = await Promise.all([
+        const [resRes, resPat, resExt, resClubs] = await Promise.all([
           api.get(`/competitions/${id}/resultados`),
           api.get('/patinadores'),
-          api.get('/patinadores-externos')
+          api.get('/patinadores-externos'),
+          api.get('/clubs')
         ]);
         setResultados(resRes.data);
         setPatinadores(resPat.data);
         setExternos(resExt.data);
+        setClubes(resClubs.data);
       } catch (err) {
         console.error(err);
         setError('Error al cargar resultados');
@@ -136,12 +139,14 @@ export default function ResultadosCompetencia() {
         payload.invitado = invitado;
       }
       await api.post(`/competitions/${id}/resultados/manual`, payload);
-      const [resRes, resExt] = await Promise.all([
+      const [resRes, resExt, resClubs] = await Promise.all([
         api.get(`/competitions/${id}/resultados`),
-        api.get('/patinadores-externos')
+        api.get('/patinadores-externos'),
+        api.get('/clubs')
       ]);
       setResultados(resRes.data);
       setExternos(resExt.data);
+      setClubes(resClubs.data);
       setPuntos('');
       setDorsal('');
       setPatinadorId('');
@@ -334,12 +339,18 @@ export default function ResultadosCompetencia() {
                       <input
                         className="form-control"
                         placeholder="Club"
+                        list="lista-clubes"
                         value={invitado.club}
                         onChange={(e) =>
                           setInvitado({ ...invitado, club: e.target.value })
                         }
                         required
                       />
+                      <datalist id="lista-clubes">
+                        {clubes.map((c) => (
+                          <option key={c._id} value={c.nombre} />
+                        ))}
+                      </datalist>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- track clubs in new `Club` model and normalize names to avoid duplicates
- list clubs via `/api/clubs` and associate them when saving external results
- show club suggestions on results page using a datalist

## Testing
- `npm test` (backend-auth)
- `npm test` *(fails: Missing script "test")* (frontend-auth)
- `npm run lint` (frontend-auth)


------
https://chatgpt.com/codex/tasks/task_e_68ad9e57bdcc8320bf4147d1d21f81a0