### PR TITLE
Adjust news grid layout

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -82,17 +82,7 @@ export default function Home() {
               </div>
             </div>
           )}
-          {displayedNews[1] && (
-            <div className="news-item top-right" key={displayedNews[1]._id}>
-              {displayedNews[1].imagen && (
-                <img src={displayedNews[1].imagen} alt="imagen noticia" />
-              )}
-              <div className="overlay">
-                <h6>{displayedNews[1].titulo}</h6>
-              </div>
-            </div>
-          )}
-          <div className="patinadores-card middle-right">
+          <div className="patinadores-card top-right">
             {currentPatinador ? (
               <>
                 {currentPatinador.foto && (
@@ -110,8 +100,18 @@ export default function Home() {
               </div>
             )}
           </div>
+          {displayedNews[1] && (
+            <div className="news-item bottom-left" key={displayedNews[1]._id}>
+              {displayedNews[1].imagen && (
+                <img src={displayedNews[1].imagen} alt="imagen noticia" />
+              )}
+              <div className="overlay">
+                <h6>{displayedNews[1].titulo}</h6>
+              </div>
+            </div>
+          )}
           {displayedNews[2] && (
-            <div className="news-item bottom-left" key={displayedNews[2]._id}>
+            <div className="news-item bottom-middle-left" key={displayedNews[2]._id}>
               {displayedNews[2].imagen && (
                 <img src={displayedNews[2].imagen} alt="imagen noticia" />
               )}
@@ -121,7 +121,7 @@ export default function Home() {
             </div>
           )}
           {displayedNews[3] && (
-            <div className="news-item bottom-middle" key={displayedNews[3]._id}>
+            <div className="news-item bottom-middle-right" key={displayedNews[3]._id}>
               {displayedNews[3].imagen && (
                 <img src={displayedNews[3].imagen} alt="imagen noticia" />
               )}

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -183,8 +183,8 @@ body.dark-mode .btn-primary {
 /* News grid layout */
 .news-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 200px);
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(2, 200px);
   gap: 1rem;
 }
 
@@ -214,31 +214,31 @@ body.dark-mode .btn-primary {
 }
 
 .news-item.large {
-  grid-column: 1 / span 2;
-  grid-row: 1 / span 2;
-}
-
-.news-item.top-right {
-  grid-column: 3;
+  grid-column: 1 / span 3;
   grid-row: 1;
 }
 
-.patinadores-card.middle-right {
-  grid-column: 3;
-  grid-row: 2;
+.patinadores-card.top-right {
+  grid-column: 4;
+  grid-row: 1;
 }
 
 .news-item.bottom-left {
   grid-column: 1;
-  grid-row: 3;
+  grid-row: 2;
 }
 
-.news-item.bottom-middle {
+.news-item.bottom-middle-left {
   grid-column: 2;
-  grid-row: 3;
+  grid-row: 2;
+}
+
+.news-item.bottom-middle-right {
+  grid-column: 3;
+  grid-row: 2;
 }
 
 .news-item.bottom-right {
-  grid-column: 3;
-  grid-row: 3;
+  grid-column: 4;
+  grid-row: 2;
 }


### PR DESCRIPTION
## Summary
- display four news cards on the bottom row
- expand top news card across three columns and reposition patinadores card

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adab31307c8320b4716ed6a39b7c99