### PR TITLE
Add label and snippet to bottom news cards

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -103,40 +103,60 @@ export default function Home() {
           {displayedNews[1] && (
             <div className="news-item bottom-left" key={displayedNews[1]._id}>
               {displayedNews[1].imagen && (
-                <img src={displayedNews[1].imagen} alt="imagen noticia" />
+                <div className="image-container">
+                  <img src={displayedNews[1].imagen} alt="imagen noticia" />
+                  <div className="news-label">NOTICIA</div>
+                  <div className="news-label-line" />
+                </div>
               )}
-              <div className="overlay">
+              <div className="news-info">
                 <h6>{displayedNews[1].titulo}</h6>
+                <p>{displayedNews[1].contenido?.slice(0, 80)}...</p>
               </div>
             </div>
           )}
           {displayedNews[2] && (
             <div className="news-item bottom-middle-left" key={displayedNews[2]._id}>
               {displayedNews[2].imagen && (
-                <img src={displayedNews[2].imagen} alt="imagen noticia" />
+                <div className="image-container">
+                  <img src={displayedNews[2].imagen} alt="imagen noticia" />
+                  <div className="news-label">NOTICIA</div>
+                  <div className="news-label-line" />
+                </div>
               )}
-              <div className="overlay">
+              <div className="news-info">
                 <h6>{displayedNews[2].titulo}</h6>
+                <p>{displayedNews[2].contenido?.slice(0, 80)}...</p>
               </div>
             </div>
           )}
           {displayedNews[3] && (
             <div className="news-item bottom-middle-right" key={displayedNews[3]._id}>
               {displayedNews[3].imagen && (
-                <img src={displayedNews[3].imagen} alt="imagen noticia" />
+                <div className="image-container">
+                  <img src={displayedNews[3].imagen} alt="imagen noticia" />
+                  <div className="news-label">NOTICIA</div>
+                  <div className="news-label-line" />
+                </div>
               )}
-              <div className="overlay">
+              <div className="news-info">
                 <h6>{displayedNews[3].titulo}</h6>
+                <p>{displayedNews[3].contenido?.slice(0, 80)}...</p>
               </div>
             </div>
           )}
           {displayedNews[4] && (
             <div className="news-item bottom-right" key={displayedNews[4]._id}>
               {displayedNews[4].imagen && (
-                <img src={displayedNews[4].imagen} alt="imagen noticia" />
+                <div className="image-container">
+                  <img src={displayedNews[4].imagen} alt="imagen noticia" />
+                  <div className="news-label">NOTICIA</div>
+                  <div className="news-label-line" />
+                </div>
               )}
-              <div className="overlay">
+              <div className="news-info">
                 <h6>{displayedNews[4].titulo}</h6>
+                <p>{displayedNews[4].contenido?.slice(0, 80)}...</p>
               </div>
             </div>
           )}

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -184,7 +184,7 @@ body.dark-mode .btn-primary {
 .news-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: repeat(2, 200px);
+  grid-template-rows: 200px auto;
   gap: 1rem;
 }
 
@@ -241,4 +241,49 @@ body.dark-mode .btn-primary {
 .news-item.bottom-right {
   grid-column: 4;
   grid-row: 2;
+}
+
+/* Bottom row news card styles */
+.news-item .image-container {
+  position: relative;
+  height: 200px;
+  overflow: hidden;
+}
+
+.news-item .news-label {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 25%;
+  height: 30px;
+  background: #003366;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: bold;
+  clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%);
+}
+
+.news-item .news-label-line {
+  position: absolute;
+  bottom: 0;
+  left: 25%;
+  width: 75%;
+  height: 3px;
+  background: #003366;
+}
+
+.news-item .news-info {
+  padding-top: 0.5rem;
+}
+
+.news-item .news-info h6 {
+  margin: 0 0 0.25rem 0;
+}
+
+.news-item .news-info p {
+  margin: 0;
+  font-size: 0.875rem;
 }


### PR DESCRIPTION
## Summary
- show title and content snippet below images on bottom row news cards
- overlay dark-blue NOTICIA label with diagonal corner and trailing line
- adjust grid rows and add supporting styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adaec0cde48320af8fdf817495d6ed