### PR TITLE
Adjust news label diagonal

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -263,16 +263,18 @@ body.dark-mode .btn-primary {
   justify-content: center;
   font-size: 0.75rem;
   font-weight: bold;
-  clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%);
+  clip-path: polygon(0 0, 100% 0, 65% 100%, 0 100%);
 }
 
 .news-item .news-label-line {
   position: absolute;
   bottom: 0;
-  left: 25%;
-  width: 75%;
-  height: 3px;
+  left: 16.25%;
+  width: calc(100% - 16.25%);
+  height: 5px;
   background: #003366;
+  transform-origin: left bottom;
+  transform: rotate(110deg);
 }
 
 .news-item .news-info {


### PR DESCRIPTION
## Summary
- tilt "NOTICIA" label corner to ~110° and rotate trailing line to match
- widen and align line flush with label for better visual continuity

## Testing
- `npm test` *(frontend-auth: missing script)*
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adb18f701c83208c4a4b26039a11d6