### PR TITLE
Fix news label diagonal line orientation and visibility

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -191,8 +191,15 @@ body.dark-mode .btn-primary {
 .news-item,
 .patinadores-card {
   position: relative;
-  overflow: hidden;
   border-radius: 0.5rem;
+}
+
+.patinadores-card {
+  overflow: hidden;
+}
+
+.news-item {
+  overflow: visible;
 }
 
 .news-item img,
@@ -200,6 +207,7 @@ body.dark-mode .btn-primary {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  border-radius: inherit;
 }
 
 .news-item .overlay,
@@ -274,7 +282,7 @@ body.dark-mode .btn-primary {
   height: 5px;
   background: #003366;
   transform-origin: left bottom;
-  transform: rotate(110deg);
+  transform: rotate(-110deg);
 }
 
 .news-item .news-info {


### PR DESCRIPTION
## Summary
- Correct news label's diagonal line orientation
- Allow line to extend beyond image by adjusting overflow and border radius styles

## Testing
- `cd frontend-auth && npm test` *(fails: Missing script "test")*
- `cd ../backend-auth && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb55d110c83208743cf8f7fffd5ba