### PR TITLE
Fix news label orientation and line

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -271,18 +271,16 @@ body.dark-mode .btn-primary {
   justify-content: center;
   font-size: 0.75rem;
   font-weight: bold;
-  clip-path: polygon(0 0, 100% 0, 65% 100%, 0 100%);
+  clip-path: polygon(35% 0, 100% 0, 100% 100%, 0 100%);
 }
 
 .news-item .news-label-line {
   position: absolute;
   bottom: 0;
-  left: 16.25%;
-  width: calc(100% - 16.25%);
+  left: 25%;
+  width: 75%;
   height: 5px;
   background: #003366;
-  transform-origin: left bottom;
-  transform: rotate(-110deg);
 }
 
 .news-item .news-info {


### PR DESCRIPTION
## Summary
- Flip news label clip-path to orient diagonal correctly
- Replace angled separator with horizontal line

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb6cc5444832084500c99b6ff8817