### PR TITLE
Orient news label diagonal to right

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -271,7 +271,7 @@ body.dark-mode .btn-primary {
   justify-content: center;
   font-size: 0.75rem;
   font-weight: bold;
-  clip-path: polygon(35% 0, 100% 0, 100% 100%, 0 100%);
+  clip-path: polygon(0 0, calc(100% - 5px) 0, 100% 100%, 0 100%);
 }
 
 .news-item .news-label-line {


### PR DESCRIPTION
## Summary
- adjust news label clip-path so diagonal rises from right side at ~100°

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb9432fcc8320beb9b667ce1b1487