### PR TITLE
Refine news label angle and corner styling

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -256,6 +256,7 @@ body.dark-mode .btn-primary {
   position: relative;
   height: 200px;
   overflow: hidden;
+  border-radius: inherit;
 }
 
 .news-item .news-label {
@@ -271,7 +272,9 @@ body.dark-mode .btn-primary {
   justify-content: center;
   font-size: 0.75rem;
   font-weight: bold;
-  clip-path: polygon(0 0, calc(100% - 5px) 0, 100% 100%, 0 100%);
+  clip-path: polygon(0 0, calc(100% - 11px) 0, 100% 100%, 0 100%);
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
 }
 
 .news-item .news-label-line {


### PR DESCRIPTION
## Summary
- Tilt news labels to 110° using clip-path
- Add rounded corners to news labels and image containers for smoother visuals

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adbe0b1a0c8320be6529ed2c1a5ea9