### PR TITLE
style: improve card title and spacing

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -50,6 +50,15 @@ body {
   color: var(--text-color);
 }
 
+.card-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.card-text {
+  margin-top: 0.5rem;
+}
+
 .btn-primary {
   background-color: var(--secondary-color);
   border-color: var(--secondary-color);


### PR DESCRIPTION
## Summary
- make card titles larger and bold
- add spacing between card title and text

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc3c18de083208d06878db853fa68