### PR TITLE
feat: redesign top news card layout

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -74,12 +74,17 @@ export default function Home() {
         <div className="news-grid">
           {displayedNews[0] && (
             <div className="news-item large" key={displayedNews[0]._id}>
-              {displayedNews[0].imagen && (
-                <img src={displayedNews[0].imagen} alt="imagen noticia" />
-              )}
-              <div className="overlay">
+              <div className="top-news-text">
+                <div className="news-label-top">NOTICIA</div>
+                <div className="news-label-top-line" />
                 <h5>{displayedNews[0].titulo}</h5>
+                <p>{displayedNews[0].contenido?.slice(0, 100)}...</p>
               </div>
+              {displayedNews[0].imagen && (
+                <div className="top-news-image">
+                  <img src={displayedNews[0].imagen} alt="imagen noticia" />
+                </div>
+              )}
             </div>
           )}
           <div className="patinadores-card top-right">

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -307,3 +307,58 @@ body.dark-mode .btn-primary {
   margin: 0;
   font-size: 0.875rem;
 }
+
+/* Top news card styles */
+.news-item.large {
+  display: flex;
+  height: 200px;
+}
+
+.news-item.large .top-news-text {
+  flex: 1;
+  padding: 1rem;
+  padding-top: 2.5rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.news-item.large .top-news-image {
+  flex: 2;
+  height: 100%;
+}
+
+.news-item.large .top-news-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+}
+
+.news-item.large .news-label-top {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 25%;
+  height: 30px;
+  background: #003366;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: bold;
+  clip-path: polygon(0 0, 100% 0, calc(100% - 11px) 100%, 0 100%);
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.news-item.large .news-label-top-line {
+  position: absolute;
+  top: 0;
+  left: 25%;
+  width: 75%;
+  height: 5px;
+  background: #003366;
+}


### PR DESCRIPTION
## Summary
- add text section with title and snippet to top news card
- include reversed-angle "NOTICIA" label and connecting line

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc796d1e88320be32964f9d3e3c26