### PR TITLE
Add footer and borders to news cards

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -117,6 +117,15 @@ export default function Home() {
               <div className="news-info">
                 <h6>{displayedNews[1].titulo}</h6>
                 <p>{displayedNews[1].contenido?.slice(0, 80)}...</p>
+                <div className="news-divider" />
+                <div className="news-footer">
+                  <img
+                    src="/APM.png"
+                    alt="logo patín carrera"
+                    className="news-footer-logo"
+                  />
+                  <span>Patín carrera General Rodríguez</span>
+                </div>
               </div>
             </div>
           )}
@@ -132,6 +141,15 @@ export default function Home() {
               <div className="news-info">
                 <h6>{displayedNews[2].titulo}</h6>
                 <p>{displayedNews[2].contenido?.slice(0, 80)}...</p>
+                <div className="news-divider" />
+                <div className="news-footer">
+                  <img
+                    src="/APM.png"
+                    alt="logo patín carrera"
+                    className="news-footer-logo"
+                  />
+                  <span>Patín carrera General Rodríguez</span>
+                </div>
               </div>
             </div>
           )}
@@ -147,6 +165,15 @@ export default function Home() {
               <div className="news-info">
                 <h6>{displayedNews[3].titulo}</h6>
                 <p>{displayedNews[3].contenido?.slice(0, 80)}...</p>
+                <div className="news-divider" />
+                <div className="news-footer">
+                  <img
+                    src="/APM.png"
+                    alt="logo patín carrera"
+                    className="news-footer-logo"
+                  />
+                  <span>Patín carrera General Rodríguez</span>
+                </div>
               </div>
             </div>
           )}
@@ -162,6 +189,15 @@ export default function Home() {
               <div className="news-info">
                 <h6>{displayedNews[4].titulo}</h6>
                 <p>{displayedNews[4].contenido?.slice(0, 80)}...</p>
+                <div className="news-divider" />
+                <div className="news-footer">
+                  <img
+                    src="/APM.png"
+                    alt="logo patín carrera"
+                    className="news-footer-logo"
+                  />
+                  <span>Patín carrera General Rodríguez</span>
+                </div>
               </div>
             </div>
           )}

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -209,6 +209,7 @@ body.dark-mode .btn-primary {
 
 .news-item {
   overflow: visible;
+  border: 1px solid #003366;
 }
 
 .news-item img,
@@ -306,6 +307,26 @@ body.dark-mode .btn-primary {
 .news-item .news-info p {
   margin: 0;
   font-size: 0.875rem;
+}
+
+.news-item .news-info .news-divider {
+  margin-top: 0.5rem;
+  height: 1px;
+  background: #003366;
+  width: 100%;
+}
+
+.news-item .news-info .news-footer {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.news-item .news-info .news-footer-logo {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
 }
 
 /* Top news card styles */


### PR DESCRIPTION
## Summary
- add club logo and label beneath bottom row news snippets
- draw dark blue borders around all news cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aee94e95748320b594ba1e150c1230