### PR TITLE
feat: improve news cards interactivity

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -20,6 +20,7 @@ import ListaBuenaFe from './pages/ListaBuenaFe';
 import ResultadosCompetencia from './pages/ResultadosCompetencia';
 import SolicitarSeguro from './pages/SolicitarSeguro';
 import RankingTorneo from './pages/RankingTorneo';
+import VerNoticia from './pages/VerNoticia';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -34,6 +35,7 @@ function AppRoutes() {
       <Routes>
         <Route path="/" element={<Auth />} />
         <Route path="/home" element={<Home />} />
+        <Route path="/noticias/:id" element={<VerNoticia />} />
         <Route path="/torneos" element={<ProtectedRoute><Torneos /></ProtectedRoute>} />
         <Route path="/torneos/:id" element={<ProtectedRoute><Competencias /></ProtectedRoute>} />
         <Route

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -73,7 +73,11 @@ export default function Home() {
         <h1 className="mb-4">Noticias</h1>
         <div className="news-grid">
           {displayedNews[0] && (
-            <div className="news-item large" key={displayedNews[0]._id}>
+            <Link
+              to={`/noticias/${displayedNews[0]._id}`}
+              className="news-item large"
+              key={displayedNews[0]._id}
+            >
               <div className="top-news-text">
                 <div className="news-label-top">NOTICIA</div>
                 <div className="news-label-top-line" />
@@ -85,7 +89,7 @@ export default function Home() {
                   <img src={displayedNews[0].imagen} alt="imagen noticia" />
                 </div>
               )}
-            </div>
+            </Link>
           )}
           <div className="patinadores-card top-right">
             {currentPatinador ? (
@@ -106,7 +110,11 @@ export default function Home() {
             )}
           </div>
           {displayedNews[1] && (
-            <div className="news-item bottom-left" key={displayedNews[1]._id}>
+            <Link
+              to={`/noticias/${displayedNews[1]._id}`}
+              className="news-item bottom-left"
+              key={displayedNews[1]._id}
+            >
               {displayedNews[1].imagen && (
                 <div className="image-container">
                   <img src={displayedNews[1].imagen} alt="imagen noticia" />
@@ -120,17 +128,21 @@ export default function Home() {
                 <div className="news-divider" />
                 <div className="news-footer">
                   <img
-                    src="/APM.png"
+                    src="/vite.svg"
                     alt="logo patín carrera"
                     className="news-footer-logo"
                   />
                   <span>Patín carrera General Rodríguez</span>
                 </div>
               </div>
-            </div>
+            </Link>
           )}
           {displayedNews[2] && (
-            <div className="news-item bottom-middle-left" key={displayedNews[2]._id}>
+            <Link
+              to={`/noticias/${displayedNews[2]._id}`}
+              className="news-item bottom-middle-left"
+              key={displayedNews[2]._id}
+            >
               {displayedNews[2].imagen && (
                 <div className="image-container">
                   <img src={displayedNews[2].imagen} alt="imagen noticia" />
@@ -144,17 +156,21 @@ export default function Home() {
                 <div className="news-divider" />
                 <div className="news-footer">
                   <img
-                    src="/APM.png"
+                    src="/vite.svg"
                     alt="logo patín carrera"
                     className="news-footer-logo"
                   />
                   <span>Patín carrera General Rodríguez</span>
                 </div>
               </div>
-            </div>
+            </Link>
           )}
           {displayedNews[3] && (
-            <div className="news-item bottom-middle-right" key={displayedNews[3]._id}>
+            <Link
+              to={`/noticias/${displayedNews[3]._id}`}
+              className="news-item bottom-middle-right"
+              key={displayedNews[3]._id}
+            >
               {displayedNews[3].imagen && (
                 <div className="image-container">
                   <img src={displayedNews[3].imagen} alt="imagen noticia" />
@@ -168,17 +184,21 @@ export default function Home() {
                 <div className="news-divider" />
                 <div className="news-footer">
                   <img
-                    src="/APM.png"
+                    src="/vite.svg"
                     alt="logo patín carrera"
                     className="news-footer-logo"
                   />
                   <span>Patín carrera General Rodríguez</span>
                 </div>
               </div>
-            </div>
+            </Link>
           )}
           {displayedNews[4] && (
-            <div className="news-item bottom-right" key={displayedNews[4]._id}>
+            <Link
+              to={`/noticias/${displayedNews[4]._id}`}
+              className="news-item bottom-right"
+              key={displayedNews[4]._id}
+            >
               {displayedNews[4].imagen && (
                 <div className="image-container">
                   <img src={displayedNews[4].imagen} alt="imagen noticia" />
@@ -192,14 +212,14 @@ export default function Home() {
                 <div className="news-divider" />
                 <div className="news-footer">
                   <img
-                    src="/APM.png"
+                    src="/vite.svg"
                     alt="logo patín carrera"
                     className="news-footer-logo"
                   />
                   <span>Patín carrera General Rodríguez</span>
                 </div>
               </div>
-            </div>
+            </Link>
           )}
         </div>
       </div>

--- a/frontend-auth/src/pages/VerNoticia.jsx
+++ b/frontend-auth/src/pages/VerNoticia.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+
+export default function VerNoticia() {
+  const { id } = useParams();
+  const [noticia, setNoticia] = useState(null);
+
+  useEffect(() => {
+    const fetchNoticia = async () => {
+      try {
+        const res = await api.get(`/news/${id}`);
+        setNoticia(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchNoticia();
+  }, [id]);
+
+  if (!noticia) {
+    return <div className="container mt-4">Cargando...</div>;
+  }
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-3">{noticia.titulo}</h1>
+      {noticia.imagen && (
+        <img
+          src={noticia.imagen}
+          alt="imagen noticia"
+          className="img-fluid mb-3"
+        />
+      )}
+      <p>{noticia.contenido}</p>
+      <div className="mt-3 d-flex align-items-center gap-2">
+        <img src="/vite.svg" alt="logo patín carrera" width="30" height="30" />
+        <span>Patín carrera General Rodríguez</span>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -210,6 +210,22 @@ body.dark-mode .btn-primary {
 .news-item {
   overflow: visible;
   border: 1px solid #003366;
+  width: 95%;
+  margin: 0 auto;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+
+.news-item:hover {
+  transform: scale(1.03);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+}
+
+.news-item:active {
+  transform: scale(0.97);
 }
 
 .news-item img,
@@ -297,7 +313,7 @@ body.dark-mode .btn-primary {
 }
 
 .news-item .news-info {
-  padding-top: 0.5rem;
+  padding: 0.5rem;
 }
 
 .news-item .news-info h6 {


### PR DESCRIPTION
## Summary
- make news cards use navbar logo and add hover/press animations
- tighten card layout with padding, shadow, and narrower width
- add individual news page and routing for full article view

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeed6aba4883209e91eced6223f766