### PR TITLE
feat: add endpoint to fetch news by id

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -565,6 +565,32 @@ app.get('/api/news', async (req, res) => {
   }
 });
 
+app.get('/api/news/:id', async (req, res) => {
+  try {
+    const noticia = await News.findById(req.params.id).populate(
+      'autor',
+      'nombre apellido'
+    );
+    if (!noticia) {
+      return res.status(404).json({ mensaje: 'Noticia no encontrada' });
+    }
+    const respuesta = {
+      _id: noticia._id,
+      titulo: noticia.titulo,
+      contenido: noticia.contenido,
+      imagen: noticia.imagen,
+      autor: noticia.autor
+        ? `${noticia.autor.nombre} ${noticia.autor.apellido}`
+        : 'Anónimo',
+      fecha: noticia.fecha
+    };
+    res.json(respuesta);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al obtener la noticia' });
+  }
+});
+
 app.post(
   '/api/news',
   protegerRuta,


### PR DESCRIPTION
## Summary
- add API endpoint to retrieve a single news article by id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef01c88748320a192596633b24a26