### PR TITLE
feat: add responsive layout for news grid

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -399,3 +399,25 @@ body.dark-mode .btn-primary {
   height: 5px;
   background: #003366;
 }
+
+@media (max-width: 768px) {
+  .news-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+  }
+
+  .news-item,
+  .patinadores-card {
+    grid-column: auto !important;
+    grid-row: auto !important;
+  }
+
+  .news-item.large {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .news-item.large .top-news-image {
+    height: 200px;
+  }
+}


### PR DESCRIPTION
## Summary
- adjust news grid to single-column layout on small screens
- reset item positioning for mobile
- make large news card stack vertically

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68aef337831483209507f8f8f8ba220d