### PR TITLE
Add mini news cards and update site background

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -57,6 +57,7 @@ export default function Home() {
   }
 
   const currentPatinador = patinadores[currentPatIndex];
+  const latestNews = news.slice(0, 4);
 
   return (
     <>
@@ -221,6 +222,36 @@ export default function Home() {
               </div>
             </Link>
           )}
+        </div>
+      </div>
+      <div className="container mt-4">
+        <div className="mini-news-container">
+          {latestNews.map((item) => (
+            <Link
+              key={item._id}
+              to={`/noticias/${item._id}`}
+              className="mini-news-card"
+            >
+              {item.imagen && (
+                <img src={item.imagen} alt="imagen noticia" />
+              )}
+              <div className="mini-news-info">
+                <div className="mini-news-header">
+                  <img
+                    src="/vite.svg"
+                    alt="logo patín carrera"
+                    className="mini-news-logo"
+                  />
+                  <span>Patín carrera General Rodríguez</span>
+                </div>
+                <h6>
+                  {item.titulo.length > 60
+                    ? `${item.titulo.slice(0, 60)}...`
+                    : item.titulo}
+                </h6>
+              </div>
+            </Link>
+          ))}
         </div>
       </div>
     </>

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -1,7 +1,7 @@
 :root {
   --primary-color: #007bff;
   --secondary-color: #28a745;
-  --bg-color: #ffffff;
+  --bg-color: #EBEBEB;
   --text-color: #000000;
   --card-bg: #ffffff;
 }
@@ -417,7 +417,66 @@ body.dark-mode .btn-primary {
     height: auto;
   }
 
-  .news-item.large .top-news-image {
+.news-item.large .top-news-image {
     height: 200px;
+  }
+}
+
+/* Mini news cards */
+.mini-news-container {
+  display: flex;
+  gap: 1rem;
+}
+
+.mini-news-card {
+  display: flex;
+  background-color: var(--card-bg);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+  color: inherit;
+  flex: 1;
+}
+
+.mini-news-card img {
+  width: 40%;
+  object-fit: cover;
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.mini-news-info {
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+}
+
+.mini-news-header {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.mini-news-logo {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+
+.mini-news-info h6 {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 768px) {
+  .mini-news-container {
+    flex-direction: column;
+  }
+
+  .mini-news-card img {
+    width: 30%;
   }
 }


### PR DESCRIPTION
## Summary
- Display four small news cards below main news section with logo and truncated titles
- Set global background color to #EBEBEB

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aef9c54c4083208d67710303d941c8