### PR TITLE
style mini news cards and logos

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -343,6 +343,8 @@ body.dark-mode .btn-primary {
   width: 20px;
   height: 20px;
   object-fit: contain;
+  border-radius: 50%;
+  border: 1px solid #ccc;
 }
 
 /* Top news card styles */
@@ -430,7 +432,7 @@ body.dark-mode .btn-primary {
 
 .mini-news-card {
   display: flex;
-  background-color: var(--card-bg);
+  background-color: #EBEBEB;
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   text-decoration: none;
@@ -461,9 +463,11 @@ body.dark-mode .btn-primary {
 }
 
 .mini-news-logo {
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   object-fit: contain;
+  border-radius: 50%;
+  border: 1px solid #ccc;
 }
 
 .mini-news-info h6 {


### PR DESCRIPTION
## Summary
- set mini news card background to #EBEBEB
- round and border logos in news cards
- shrink and circle mini news logos

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aefc6209f08320bb85b82d671e2731