### PR TITLE
style: refine news card colors and spacing

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -217,6 +217,7 @@ body.dark-mode .btn-primary {
   cursor: pointer;
   text-decoration: none;
   color: inherit;
+  background-color: #fff;
 }
 
 .news-item:hover {
@@ -428,6 +429,8 @@ body.dark-mode .btn-primary {
 .mini-news-container {
   display: flex;
   gap: 1rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 .mini-news-card {


### PR DESCRIPTION
## Summary
- ensure main news cards use a white background
- keep mini news cards gray and add vertical spacing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aefea0e4748320a3391ce1eadabefe