### PR TITLE
Increase spacing around mini news cards

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -224,7 +224,7 @@ export default function Home() {
           )}
         </div>
       </div>
-      <div className="container mt-4">
+      <div className="container mt-5 mb-5">
         <div className="mini-news-container">
           {latestNews.map((item) => (
             <Link

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -429,8 +429,8 @@ body.dark-mode .btn-primary {
 .mini-news-container {
   display: flex;
   gap: 1rem;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 
 .mini-news-card {


### PR DESCRIPTION
## Summary
- Increase container margins to give mini news cards more space above and below
- Double vertical spacing inside mini-news container for clearer separation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af062cf7d483209da9158d1f54c91c