### PR TITLE
Increase patinadores card height by 40%

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -256,7 +256,7 @@ body.dark-mode .btn-primary {
 .patinadores-card.top-right {
   grid-column: 4;
   grid-row: 1;
-  height: 450px;
+  height: 630px; /* 40% taller to showcase skater photos */
 }
 
 .news-item.bottom-left {


### PR DESCRIPTION
## Summary
- enlarge patinadores card height to better showcase skater photos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0b6f18588320a75a535ca8806f43