### PR TITLE
Mostrar próxima competencia en la portada

### DIFF
--- a/backend-auth/models/Competencia.js
+++ b/backend-auth/models/Competencia.js
@@ -5,6 +5,7 @@ const competenciaSchema = new mongoose.Schema(
     nombre: { type: String, required: true },
     torneo: { type: mongoose.Schema.Types.ObjectId, ref: 'Torneo', required: true },
     fecha: { type: Date, required: true },
+    imagen: { type: String },
     listaBuenaFe: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Patinador' }]
   },
   { timestamps: true }

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -30,9 +30,16 @@ export default function Competencias() {
   const crearCompetencia = async (e) => {
     e.preventDefault();
     try {
-      await api.post(`/tournaments/${id}/competitions`, { nombre, fecha });
+      const formData = new FormData();
+      formData.append('nombre', nombre);
+      formData.append('fecha', fecha);
+      if (e.target.imagen.files[0]) {
+        formData.append('imagen', e.target.imagen.files[0]);
+      }
+      await api.post(`/tournaments/${id}/competitions`, formData);
       setNombre('');
       setFecha('');
+      e.target.imagen.value = '';
       const res = await api.get(`/tournaments/${id}/competitions`);
       setCompetencias(res.data);
     } catch (err) {
@@ -77,8 +84,8 @@ export default function Competencias() {
     <div className="container mt-3">
       <h2>Competencias</h2>
       {rol === 'Delegado' && (
-        <form onSubmit={crearCompetencia} className="row g-2 mb-3">
-          <div className="col-md-5">
+        <form onSubmit={crearCompetencia} className="row g-2 mb-3" encType="multipart/form-data">
+          <div className="col-md-4">
             <input
               type="text"
               className="form-control"
@@ -88,7 +95,7 @@ export default function Competencias() {
               required
             />
           </div>
-          <div className="col-md-4">
+          <div className="col-md-3">
             <input
               type="date"
               className="form-control"
@@ -98,6 +105,9 @@ export default function Competencias() {
             />
           </div>
           <div className="col-md-3">
+            <input type="file" name="imagen" className="form-control" accept="image/*" />
+          </div>
+          <div className="col-md-2">
             <button type="submit" className="btn btn-primary w-100">
               Crear
             </button>

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -7,6 +7,7 @@ export default function Home() {
   const [patinadores, setPatinadores] = useState([]);
   const [currentNewsIndex, setCurrentNewsIndex] = useState(0);
   const [currentPatIndex, setCurrentPatIndex] = useState(0);
+  const [nextCompetition, setNextCompetition] = useState(null);
 
   useEffect(() => {
     const cargarNoticias = async () => {
@@ -27,16 +28,35 @@ export default function Home() {
       }
     };
 
+    const cargarCompetencia = async () => {
+      try {
+        const compRes = await api.get('/competencias');
+        const comps = compRes.data;
+        if (comps.length > 0) {
+          const now = new Date();
+          const upcoming = comps.filter((c) => new Date(c.fecha) >= now);
+          if (upcoming.length > 0) {
+            setNextCompetition(upcoming[0]);
+          } else {
+            setNextCompetition(comps[comps.length - 1]);
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
     cargarNoticias();
     if (localStorage.getItem('token')) {
       cargarPatinadores();
     }
+    cargarCompetencia();
   }, []);
 
   useEffect(() => {
     if (news.length > 0) {
       const interval = setInterval(() => {
-        setCurrentNewsIndex((prev) => (prev + 5) % news.length);
+        setCurrentNewsIndex((prev) => (prev + 4) % news.length);
       }, 5000);
       return () => clearInterval(interval);
     }
@@ -52,7 +72,7 @@ export default function Home() {
   }, [patinadores]);
 
   const displayedNews = [];
-  for (let i = 0; i < 5 && i < news.length; i += 1) {
+  for (let i = 0; i < 4 && i < news.length; i += 1) {
     displayedNews.push(news[(currentNewsIndex + i) % news.length]);
   }
 
@@ -194,22 +214,18 @@ export default function Home() {
               </div>
             </Link>
           )}
-          {displayedNews[4] && (
-            <Link
-              to={`/noticias/${displayedNews[4]._id}`}
-              className="news-item bottom-right"
-              key={displayedNews[4]._id}
-            >
-              {displayedNews[4].imagen && (
+          {nextCompetition && (
+            <div className="news-item bottom-right">
+              {nextCompetition.imagen && (
                 <div className="image-container">
-                  <img src={displayedNews[4].imagen} alt="imagen noticia" />
-                  <div className="news-label">NOTICIA</div>
+                  <img src={nextCompetition.imagen} alt="imagen competencia" />
+                  <div className="news-label">COMPETENCIA</div>
                   <div className="news-label-line" />
                 </div>
               )}
               <div className="news-info">
-                <h6>{displayedNews[4].titulo}</h6>
-                <p>{displayedNews[4].contenido?.slice(0, 80)}...</p>
+                <h6>{nextCompetition.nombre}</h6>
+                <p>{new Date(nextCompetition.fecha).toLocaleDateString()}</p>
                 <div className="news-divider" />
                 <div className="news-footer">
                   <img
@@ -220,7 +236,7 @@ export default function Home() {
                   <span>Patín carrera General Rodríguez</span>
                 </div>
               </div>
-            </Link>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Resumen
- Permite adjuntar una imagen al crear o editar competencias
- Expone un endpoint público de competencias y muestra la próxima competencia en la portada
- Formulario de competencias acepta imagen y la portada exhibe título, fecha e imagen de la competencia más cercana

## Testing
- `npm test` (frontend) – falla: Missing script: "test"
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68af0f9800a48320a036d105eb7687bd