### PR TITLE
Fix layout overlap and show competition image

### DIFF
--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -120,8 +120,13 @@ export default function Competencias() {
         <ul className="list-group">
           {competencias.map((c) => (
             <li key={c._id} className="list-group-item d-flex justify-content-between align-items-center">
-              <div>
-                <strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}
+              <div className="d-flex align-items-center gap-3">
+                {c.imagen && (
+                  <img src={c.imagen} alt="imagen competencia" className="competencia-img" />
+                )}
+                <div>
+                  <strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}
+                </div>
               </div>
               <div className="d-flex gap-2">
                 {rol === 'Delegado' && (

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -193,7 +193,7 @@ body.dark-mode .btn-primary {
 .news-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: 450px auto;
+  grid-template-rows: 630px auto;
   gap: 1rem;
 }
 
@@ -256,7 +256,7 @@ body.dark-mode .btn-primary {
 .patinadores-card.top-right {
   grid-column: 4;
   grid-row: 1;
-  height: 630px; /* 40% taller to showcase skater photos */
+  height: 100%;
 }
 
 .news-item.bottom-left {
@@ -356,7 +356,7 @@ body.dark-mode .btn-primary {
 /* Top news card styles */
 .news-item.large {
   display: flex;
-  height: 450px;
+  height: 100%;
 }
 
 .news-item.large .top-news-text {
@@ -481,6 +481,13 @@ body.dark-mode .btn-primary {
 .mini-news-info h6 {
   margin: 0.25rem 0 0;
   font-size: 0.875rem;
+}
+
+.competencia-img {
+  width: 80px;
+  height: 50px;
+  object-fit: cover;
+  border-radius: 0.25rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Prevent next competition card from overlapping skater photos by enlarging first news row and aligning card heights
- Display uploaded competition images in the competitions list with proper styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af13e5963483209de3a1439649764f