### PR TITLE
Reduce main news card height

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -195,6 +195,7 @@ body.dark-mode .btn-primary {
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: 630px auto;
   gap: 1rem;
+  align-items: start;
 }
 
 .news-item,
@@ -357,7 +358,8 @@ body.dark-mode .btn-primary {
 /* Top news card styles */
 .news-item.large {
   display: flex;
-  height: 100%;
+  height: 400px;
+  align-self: start;
 }
 
 .news-item.large .top-news-text {


### PR DESCRIPTION
## Summary
- prevent grid items from stretching by aligning items to start
- shrink primary news card to fixed 400px height while keeping skaters card unchanged

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af194f4bb48320a2ba58958f3837a6