### PR TITLE
Adjust news grid spacing on home page

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -193,7 +193,7 @@ body.dark-mode .btn-primary {
 .news-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: 630px auto;
+  grid-template-rows: 400px auto;
   gap: 1rem;
   align-items: start;
 }
@@ -279,7 +279,7 @@ body.dark-mode .btn-primary {
   grid-column: 4;
   grid-row: 2;
   height: 200px;
-  align-self: end;
+  align-self: start;
 }
 
 /* Bottom row news card styles */


### PR DESCRIPTION
## Summary
- Reduce vertical spacing by shrinking top news grid row
- Align upcoming competition card with other bottom news cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2089fae88320a3dc389b34d51745