### PR TITLE
fix: display image for next competition card

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -216,13 +216,14 @@ export default function Home() {
           )}
           {nextCompetition && (
             <div className="news-item bottom-right">
-              {nextCompetition.imagen && (
-                <div className="image-container">
-                  <img src={nextCompetition.imagen} alt="imagen competencia" />
-                  <div className="news-label">COMPETENCIA</div>
-                  <div className="news-label-line" />
-                </div>
-              )}
+              <div className="image-container">
+                <img
+                  src={nextCompetition.imagen || '/vite.svg'}
+                  alt="imagen competencia"
+                />
+                <div className="news-label">COMPETENCIA</div>
+                <div className="news-label-line" />
+              </div>
               <div className="news-info">
                 <h6>{nextCompetition.nombre}</h6>
                 <p>{new Date(nextCompetition.fecha).toLocaleDateString()}</p>


### PR DESCRIPTION
## Summary
- ensure next competition info card always renders an image with a placeholder

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2cdef3248320820abadc2acd08d3