### PR TITLE
Fix home competition card image

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -217,10 +217,9 @@ export default function Home() {
           {nextCompetition && (
             <div className="news-item bottom-right">
               <div className="image-container">
-                <img
-                  src={nextCompetition.imagen || '/vite.svg'}
-                  alt="imagen competencia"
-                />
+                {nextCompetition.imagen && (
+                  <img src={nextCompetition.imagen} alt="imagen competencia" />
+                )}
                 <div className="news-label">COMPETENCIA</div>
                 <div className="news-label-line" />
               </div>


### PR DESCRIPTION
## Summary
- Display uploaded competition image on home page card instead of default navbar logo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af30c366708320a8a30fc1ca6bf760