### PR TITLE
Fix competition image not showing after creation

### DIFF
--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -36,7 +36,11 @@ export default function Competencias() {
       if (e.target.imagen.files[0]) {
         formData.append('imagen', e.target.imagen.files[0]);
       }
-      await api.post(`/tournaments/${id}/competitions`, formData);
+      await api.post(`/tournaments/${id}/competitions`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      });
       setNombre('');
       setFecha('');
       e.target.imagen.value = '';


### PR DESCRIPTION
## Summary
- ensure competition creation sends multipart/form-data so uploaded images are saved and displayed

## Testing
- `npm test` *(frontend-auth: missing script)*
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afbb0240bc8320b8e4511f5c4972f0