### PR TITLE
Adjust competition label width

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -220,7 +220,7 @@ export default function Home() {
                 {nextCompetition.imagen && (
                   <img src={nextCompetition.imagen} alt="imagen competencia" />
                 )}
-                <div className="news-label">COMPETENCIA</div>
+                <div className="news-label competition-label">COMPETENCIA</div>
                 <div className="news-label-line" />
               </div>
               <div className="news-info">

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -320,6 +320,15 @@ body.dark-mode .btn-primary {
   background: #003366;
 }
 
+.news-item .competition-label {
+  width: 40%;
+}
+
+.news-item .competition-label + .news-label-line {
+  left: 40%;
+  width: 60%;
+}
+
 .news-item .news-info {
   padding: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- widen the competition label on the home page so "COMPETENCIA" fits
- add CSS rules to expand the label width and adjust the underline

## Testing
- `npm test` (frontend-auth)
- `npm run lint` (frontend-auth)
- `npm test` (backend-auth)


------
https://chatgpt.com/codex/tasks/task_e_68afbde83a648320ac6d0c61ad02affc