### PR TITLE
Auto-refresh competition card

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -51,6 +51,8 @@ export default function Home() {
       cargarPatinadores();
     }
     cargarCompetencia();
+    const interval = setInterval(cargarCompetencia, 60000);
+    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- poll competitions every minute on home page to auto-refresh next competition card

## Testing
- ⚠️ `npm test` (frontend) – Missing script: "test"
- ✅ `npm run lint`
- ✅ `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_e_68afbf1f334c8320b802d4dbd8f87347