### PR TITLE
fix: update latest competition card after new competition

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -33,13 +33,10 @@ export default function Home() {
         const compRes = await api.get('/competencias');
         const comps = compRes.data;
         if (comps.length > 0) {
-          const now = new Date();
-          const upcoming = comps.filter((c) => new Date(c.fecha) >= now);
-          if (upcoming.length > 0) {
-            setNextCompetition(upcoming[0]);
-          } else {
-            setNextCompetition(comps[comps.length - 1]);
-          }
+          const sorted = comps.sort(
+            (a, b) => new Date(a.fecha) - new Date(b.fecha)
+          );
+          setNextCompetition(sorted[sorted.length - 1]);
         }
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- Always pick the latest competition in Home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afc2b394a483209547b302fe564d1f