### PR TITLE
Fix competition card height in news grid

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -278,13 +278,12 @@ body.dark-mode .btn-primary {
 .news-item.bottom-right {
   grid-column: 4;
   grid-row: 2;
-  height: 200px;
-  align-self: start;
+  align-self: stretch;
 }
 
 /* Bottom row news card styles */
 .news-item.bottom-right .image-container {
-  height: 100px;
+  height: 200px;
 }
 .news-item .image-container {
   position: relative;


### PR DESCRIPTION
## Summary
- stretch bottom-right competition card and use consistent image height so it matches neighboring news cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afc49cc73883209f2f777bfb2990b3