### PR TITLE
Align home news cards in second row

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -195,7 +195,7 @@ body.dark-mode .btn-primary {
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: 400px auto;
   gap: 1rem;
-  align-items: start;
+  align-items: stretch;
 }
 
 .news-item,
@@ -279,6 +279,24 @@ body.dark-mode .btn-primary {
   grid-column: 4;
   grid-row: 2;
   align-self: stretch;
+}
+
+.news-item.bottom-left,
+.news-item.bottom-middle-left,
+.news-item.bottom-middle-right,
+.news-item.bottom-right {
+  display: flex;
+  flex-direction: column;
+}
+
+.news-item.bottom-left .news-info,
+.news-item.bottom-middle-left .news-info,
+.news-item.bottom-middle-right .news-info,
+.news-item.bottom-right .news-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 /* Bottom row news card styles */


### PR DESCRIPTION
## Summary
- stretch grid items so second-row news cards match height
- add flex layout to bottom news cards and info blocks for consistent sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afc8984fa4832088365c5d4912bdab