### PR TITLE
Add additional news sections

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -77,6 +77,8 @@ export default function Home() {
 
   const currentPatinador = patinadores[currentPatIndex];
   const latestNews = news.slice(0, 4);
+  const wideNews = news.slice(4, 7);
+  const additionalNews = news.slice(7, 11);
 
   return (
     <>
@@ -269,6 +271,74 @@ export default function Home() {
           ))}
         </div>
       </div>
+      {wideNews.length > 0 && (
+        <div className="container mb-5">
+          <div className="wide-news-container">
+            {wideNews.map((item) => (
+              <Link
+                key={item._id}
+                to={`/noticias/${item._id}`}
+                className="news-item"
+              >
+                {item.imagen && (
+                  <div className="image-container">
+                    <img src={item.imagen} alt="imagen noticia" />
+                    <div className="news-label">NOTICIA</div>
+                    <div className="news-label-line" />
+                  </div>
+                )}
+                <div className="news-info">
+                  <h6>{item.titulo}</h6>
+                  <p>{item.contenido?.slice(0, 80)}...</p>
+                  <div className="news-divider" />
+                  <div className="news-footer">
+                    <img
+                      src="/vite.svg"
+                      alt="logo patín carrera"
+                      className="news-footer-logo"
+                    />
+                    <span>Patín carrera General Rodríguez</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+      {additionalNews.length > 0 && (
+        <div className="container mb-5">
+          <div className="additional-news-grid">
+            {additionalNews.map((item) => (
+              <Link
+                key={item._id}
+                to={`/noticias/${item._id}`}
+                className="news-item"
+              >
+                {item.imagen && (
+                  <div className="image-container">
+                    <img src={item.imagen} alt="imagen noticia" />
+                    <div className="news-label">NOTICIA</div>
+                    <div className="news-label-line" />
+                  </div>
+                )}
+                <div className="news-info">
+                  <h6>{item.titulo}</h6>
+                  <p>{item.contenido?.slice(0, 80)}...</p>
+                  <div className="news-divider" />
+                  <div className="news-footer">
+                    <img
+                      src="/vite.svg"
+                      alt="logo patín carrera"
+                      className="news-footer-logo"
+                    />
+                    <span>Patín carrera General Rodríguez</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -524,7 +524,33 @@ body.dark-mode .btn-primary {
     flex-direction: column;
   }
 
-  .mini-news-card img {
+.mini-news-card img {
     width: 30%;
+  }
+}
+
+.wide-news-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  width: 80%;
+  margin: 0 auto 2rem auto;
+}
+
+.additional-news-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 768px) {
+  .wide-news-container {
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
+
+  .additional-news-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add wide news row after mini-news
- append extra row of four news cards
- style containers for new rows

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afcab3dc24832083e0acfd6fbccf24