### PR TITLE
Ensure mini news card logo is circular

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -477,7 +477,7 @@ body.dark-mode .btn-primary {
   flex: 1;
 }
 
-.mini-news-card img {
+.mini-news-card > img {
   width: 40%;
   object-fit: cover;
   border-top-left-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- Restrict `.mini-news-card` image selector to only affect the primary image so embedded logos keep their intended size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03b84fd108320a571be0cd2cf025b