### PR TITLE
feat: enlarge mini news card logo and make responsive

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -500,8 +500,8 @@ body.dark-mode .btn-primary {
 }
 
 .mini-news-logo {
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   object-fit: contain;
   border-radius: 50%;
   border: 1px solid #ccc;
@@ -524,8 +524,13 @@ body.dark-mode .btn-primary {
     flex-direction: column;
   }
 
-.mini-news-card img {
+  .mini-news-card img {
     width: 30%;
+  }
+
+  .mini-news-logo {
+    width: 20px;
+    height: 20px;
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge mini news card logo for better visibility
- add responsive styling to adjust logo size on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03dac77f883209e17dbddcc32e7b6