### PR TITLE
fix: ajustar tarjetas para baja resolución

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -449,9 +449,30 @@ body.dark-mode .btn-primary {
     grid-row: auto !important;
   }
 
+  .patinadores-card {
+    order: 1;
+  }
+
+  .news-item.bottom-right {
+    order: 2;
+  }
+
   .news-item.large {
     flex-direction: column;
     height: auto;
+    order: 3;
+  }
+
+  .news-item.bottom-left {
+    order: 4;
+  }
+
+  .news-item.bottom-middle-left {
+    order: 5;
+  }
+
+  .news-item.bottom-middle-right {
+    order: 6;
   }
 
 .news-item.large .top-news-image {
@@ -502,9 +523,11 @@ body.dark-mode .btn-primary {
 .mini-news-logo {
   width: 24px;
   height: 24px;
-  object-fit: contain;
+  object-fit: cover;
+  aspect-ratio: 1 / 1;
   border-radius: 50%;
   border: 1px solid #ccc;
+  flex-shrink: 0;
 }
 
 .mini-news-info h6 {


### PR DESCRIPTION
## Summary
- Asegura que el logo de las mini noticias conserve su forma circular en pantallas pequeñas.
- Reordena las tarjetas para que en baja resolución se muestren primero los patinadores asociados y luego la próxima competencia.

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04211fdf883208371ac431a7a61e9