### PR TITLE
Ensure mini-news logos remain circular on small screens

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -547,7 +547,7 @@ body.dark-mode .btn-primary {
     flex-direction: column;
   }
 
-  .mini-news-card img {
+  .mini-news-card > img {
     width: 30%;
   }
 


### PR DESCRIPTION
## Summary
- Fix CSS selector to avoid stretching mini-news logos on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0471c0a588320afc772048ae331c8