### PR TITLE
Amplía el logo del footer

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -53,7 +53,7 @@ export default function Footer() {
               onClick={togglePinned}
               style={{ cursor: 'pointer' }}
             >
-              <img src="/robot.svg" alt="Logo" width="80" height="80" className="mb-3" />
+              <img src="/robot.svg" alt="Logo" width="400" height="400" className="mb-3" />
               {historyVisible && (
                 <div className="history-bubble">
                   <p className="mb-0 small">


### PR DESCRIPTION
## Summary
- Expande el logo del pie de página para que sea 5 veces más grande

## Testing
- `npm test` (falla: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b05f9082388320b60d54a41c018c01