### PR TITLE
feat: set footer background color

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -42,7 +42,7 @@ export default function Footer() {
   };
 
   return (
-    <footer className="bg-dark text-light mt-5">
+    <footer className="footer-custom text-light mt-5">
       <div className="container py-5">
         <div className="row">
           <div className="col-md-3 mb-4">
@@ -146,7 +146,7 @@ export default function Footer() {
           </div>
         </div>
       </div>
-      <div className="bg-secondary text-center py-2">
+      <div className="footer-custom text-center py-2">
         <small>© {new Date().getFullYear()} Todos los derechos reservados</small>
       </div>
     </footer>

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -64,6 +64,10 @@ body {
   border-color: var(--secondary-color);
 }
 
+.footer-custom {
+  background-color: #202527;
+}
+
 body.dark-mode {
   --bg-color: #2a2a2a;
   --text-color: #ffffff;


### PR DESCRIPTION
## Summary
- add reusable footer-custom class with #202527 background
- apply new background to footer and copyright sections

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b11bef50748320b3ad250777b22282