### PR TITLE
feat: robot del footer con fondo transparente

### DIFF
--- a/frontend-auth/public/robot.svg
+++ b/frontend-auth/public/robot.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="30" y="40" width="40" height="40" rx="5" fill="#555"/>
+  <circle cx="45" cy="55" r="5" fill="#fff"/>
+  <circle cx="55" cy="55" r="5" fill="#fff"/>
+  <rect x="40" y="65" width="20" height="5" fill="#fff"/>
+  <rect x="30" y="80" width="10" height="20" fill="#555"/>
+  <rect x="60" y="80" width="10" height="20" fill="#555"/>
+  <rect x="40" y="25" width="20" height="15" rx="3" fill="#555"/>
+  <line x1="50" y1="25" x2="50" y2="15" stroke="#555" stroke-width="4"/>
+  <circle cx="50" cy="10" r="5" fill="#555"/>
+</svg>

--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -53,7 +53,7 @@ export default function Footer() {
               onClick={togglePinned}
               style={{ cursor: 'pointer' }}
             >
-              <img src="data:image/webp;base64,UklGRiIAAABXRUJQVlA4TAYAAAAvAAAAAAfQ//73v/+BiOh/AAA=" alt="Logo" width="400" height="400" className="mb-3" />
+              <img src="/robot.svg" alt="Logo" width="400" height="400" className="mb-3" />
               {historyVisible && (
                 <div className="history-bubble">
                   <p className="mb-0 small">


### PR DESCRIPTION
## Summary
- replace inline base64 logo with `/robot.svg` in footer
- add transparent robot SVG asset

## Testing
- `npm test` (frontend-auth) *(fails: Missing script: "test")*
- `npm run lint` (frontend-auth)
- `npm test` (backend-auth)


------
https://chatgpt.com/codex/tasks/task_e_68b11ffb16ec832093d9d1e75f97d084