### PR TITLE
style: match navbar color with news labels

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -1,5 +1,5 @@
 :root {
-  --primary-color: #007bff;
+  --primary-color: #003366;
   --secondary-color: #28a745;
   --bg-color: #EBEBEB;
   --text-color: #000000;


### PR DESCRIPTION
## Summary
- set primary navbar color to dark blue used by news labels

## Testing
- `npm test` (backend-auth)
- `npm test` (frontend-auth; fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b12617048483209d58b81ecd5ea353