### PR TITLE
feat: role-specific patinadores views

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -59,7 +59,7 @@ function AppRoutes() {
         />
         <Route
           path="/patinadores"
-          element={<ProtectedRoute roles={['Delegado', 'Tecnico']}><ListaPatinadores /></ProtectedRoute>}
+          element={<ProtectedRoute roles={['Delegado', 'Tecnico', 'Deportista']}><ListaPatinadores /></ProtectedRoute>}
         />
         <Route
           path="/patinadores/:id"

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -87,7 +87,9 @@ export default function Navbar() {
                 ]
               }
             ]
-          : []),
+          : rol === 'Deportista'
+            ? [{ label: 'Patinadores', path: '/patinadores' }]
+            : []),
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [
               {

--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -4,6 +4,7 @@ import api from '../api';
 
 export default function ListaPatinadores() {
   const [patinadores, setPatinadores] = useState([]);
+  const rol = localStorage.getItem('rol');
 
   useEffect(() => {
     const obtenerPatinadores = async () => {
@@ -26,6 +27,26 @@ export default function ListaPatinadores() {
       console.error(err);
     }
   };
+
+  if (rol === 'Deportista') {
+    return (
+      <div className="container mt-4 deportista-container">
+        {patinadores.map((p) => (
+          <div className="deportista-card mb-4" key={p._id}>
+            {p.foto && (
+              <img src={p.foto} alt={`${p.primerNombre} ${p.apellido}`} />
+            )}
+            <div className="category-label">{p.categoria}</div>
+            <div className="category-label-line" />
+            <div className="name-label">
+              {p.primerNombre} {p.apellido}
+            </div>
+            <div className="name-label-line" />
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="container mt-4">
@@ -54,18 +75,22 @@ export default function ListaPatinadores() {
                   >
                     Ver
                   </Link>
-                  <Link
-                    to={`/patinadores/${p._id}/editar`}
-                    className="btn btn-secondary me-2"
-                  >
-                    Editar
-                  </Link>
-                  <button
-                    onClick={() => eliminarPatinador(p._id)}
-                    className="btn btn-danger"
-                  >
-                    Eliminar
-                  </button>
+                  {rol === 'Delegado' && (
+                    <>
+                      <Link
+                        to={`/patinadores/${p._id}/editar`}
+                        className="btn btn-secondary me-2"
+                      >
+                        Editar
+                      </Link>
+                      <button
+                        onClick={() => eliminarPatinador(p._id)}
+                        className="btn btn-danger"
+                      >
+                        Eliminar
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
             </div>

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -612,3 +612,78 @@ body.dark-mode .btn-primary {
   border-style: solid;
   border-color: transparent #fff transparent transparent;
 }
+
+/* Deportista patinador cards */
+.deportista-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.deportista-card {
+  position: relative;
+  width: 100%;
+  height: 80vh;
+  overflow: hidden;
+  border-radius: 0.5rem;
+}
+
+.deportista-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.deportista-card .name-label {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 60%;
+  height: 60px;
+  background: #003366;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  clip-path: polygon(0 0, calc(100% - 20px) 0, 100% 100%, 0 100%);
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.deportista-card .name-label-line {
+  position: absolute;
+  bottom: 0;
+  left: 60%;
+  width: 40%;
+  height: 10px;
+  background: #003366;
+}
+
+.deportista-card .category-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 30%;
+  height: 60px;
+  background: #003366;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  clip-path: polygon(0 0, 100% 0, calc(100% - 20px) 100%, 0 100%);
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.deportista-card .category-label-line {
+  position: absolute;
+  top: 0;
+  left: 30%;
+  width: 70%;
+  height: 10px;
+  background: #003366;
+}


### PR DESCRIPTION
## Summary
- allow deportistas to access patinadores list
- add deportivo cards with name and category labels
- hide edit/delete for técnicos and expose patinadores link for deportistas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b18e5e788483208030ffa4b394cb7b