### PR TITLE
feat: add carousel for patinador cards

### DIFF
--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -4,6 +4,7 @@ import api from '../api';
 
 export default function ListaPatinadores() {
   const [patinadores, setPatinadores] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const rol = localStorage.getItem('rol');
 
   useEffect(() => {
@@ -28,22 +29,57 @@ export default function ListaPatinadores() {
     }
   };
 
+  const nextCard = () => {
+    if (patinadores.length === 0) return;
+    setCurrentIndex((prev) => (prev + 1) % patinadores.length);
+  };
+
+  const prevCard = () => {
+    if (patinadores.length === 0) return;
+    setCurrentIndex((prev) => (prev - 1 + patinadores.length) % patinadores.length);
+  };
+
   if (rol === 'Deportista') {
     return (
       <div className="container mt-4 deportista-container">
-        {patinadores.map((p) => (
-          <div className="deportista-card mb-4" key={p._id}>
-            {p.foto && (
-              <img src={p.foto} alt={`${p.primerNombre} ${p.apellido}`} />
-            )}
-            <div className="category-label">{p.categoria}</div>
-            <div className="category-label-line" />
-            <div className="name-label">
-              {p.primerNombre} {p.apellido}
+        {patinadores.length > 1 && (
+          <button
+            type="button"
+            className="carousel-btn prev"
+            onClick={prevCard}
+            aria-label="Anterior"
+          >
+            ‹
+          </button>
+        )}
+        <div
+          className="deportista-wrapper"
+          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+        >
+          {patinadores.map((p) => (
+            <div className="deportista-card mb-4" key={p._id}>
+              {p.foto && (
+                <img src={p.foto} alt={`${p.primerNombre} ${p.apellido}`} />
+              )}
+              <div className="category-label">{p.categoria}</div>
+              <div className="category-label-line" />
+              <div className="name-label">
+                {p.primerNombre} {p.apellido}
+              </div>
+              <div className="name-label-line" />
             </div>
-            <div className="name-label-line" />
-          </div>
-        ))}
+          ))}
+        </div>
+        {patinadores.length > 1 && (
+          <button
+            type="button"
+            className="carousel-btn next"
+            onClick={nextCard}
+            aria-label="Siguiente"
+          >
+            ›
+          </button>
+        )}
       </div>
     );
   }

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -615,13 +615,18 @@ body.dark-mode .btn-primary {
 
 /* Deportista patinador cards */
 .deportista-container {
+  position: relative;
+  overflow: hidden;
+}
+
+.deportista-wrapper {
   display: flex;
-  flex-direction: column;
-  gap: 2rem;
+  transition: transform 0.5s ease;
 }
 
 .deportista-card {
   position: relative;
+  flex: 0 0 100%;
   width: 100%;
   height: 80vh;
   overflow: hidden;
@@ -686,4 +691,28 @@ body.dark-mode .btn-primary {
   width: 70%;
   height: 10px;
   background: #003366;
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: #fff;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.carousel-btn.prev {
+  left: 10px;
+}
+
+.carousel-btn.next {
+  right: 10px;
 }


### PR DESCRIPTION
## Summary
- add carousel navigation to patinador cards for deportista role
- style patinador cards for horizontal sliding with controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b194551d6483209e53abc69fd1dc9e