### PR TITLE
feat: schedule and view trainings

### DIFF
--- a/backend-auth/models/Entrenamiento.js
+++ b/backend-auth/models/Entrenamiento.js
@@ -14,7 +14,7 @@ const asistenciaSchema = new mongoose.Schema(
 
 const entrenamientoSchema = new mongoose.Schema(
   {
-    fecha: { type: Date, default: Date.now },
+    fecha: { type: Date, required: true },
     asistencias: [asistenciaSchema],
     tecnico: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
   },

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1387,8 +1387,11 @@ app.get('/api/entrenamientos/:id', protegerRuta, permitirRol('Tecnico'), async (
 app.post('/api/entrenamientos', protegerRuta, permitirRol('Tecnico'), async (req, res) => {
   try {
     const { fecha, asistencias } = req.body;
+    if (!fecha) {
+      return res.status(400).json({ mensaje: 'La fecha es obligatoria' });
+    }
     const nuevo = await Entrenamiento.create({
-      fecha: fecha || new Date(),
+      fecha,
       asistencias,
       tecnico: req.usuario.id
     });
@@ -1402,6 +1405,9 @@ app.post('/api/entrenamientos', protegerRuta, permitirRol('Tecnico'), async (req
 app.put('/api/entrenamientos/:id', protegerRuta, permitirRol('Tecnico'), async (req, res) => {
   try {
     const { asistencias, fecha } = req.body;
+    if (!fecha) {
+      return res.status(400).json({ mensaje: 'La fecha es obligatoria' });
+    }
     const actualizado = await Entrenamiento.findByIdAndUpdate(
       req.params.id,
       { asistencias, fecha },


### PR DESCRIPTION
## Summary
- require training date and validate on creation and update
- allow technicians to pick date and view training attendance

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm test` *(fails: Missing script: "test")*
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b26391e12083208f3b68089d28dac3