### PR TITLE
feat: allow técnicos to record skater progress

### DIFF
--- a/backend-auth/models/Progreso.js
+++ b/backend-auth/models/Progreso.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const progresoSchema = new mongoose.Schema(
+  {
+    patinador: { type: mongoose.Schema.Types.ObjectId, ref: 'Patinador', required: true },
+    tecnico: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    descripcion: { type: String, required: true },
+    fecha: { type: Date, default: Date.now }
+  },
+  { timestamps: true }
+);
+
+const Progreso = mongoose.model('Progreso', progresoSchema);
+export default Progreso;

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -23,6 +23,7 @@ import SolicitarSeguro from './pages/SolicitarSeguro';
 import RankingTorneo from './pages/RankingTorneo';
 import VerNoticia from './pages/VerNoticia';
 import Entrenamientos from './pages/Entrenamientos';
+import Progresos from './pages/Progresos';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -82,6 +83,10 @@ function AppRoutes() {
           <Route
             path="/entrenamientos"
             element={<ProtectedRoute roles={['Tecnico']}><Entrenamientos /></ProtectedRoute>}
+          />
+          <Route
+            path="/progresos"
+            element={<ProtectedRoute roles={['Tecnico']}><Progresos /></ProtectedRoute>}
           />
           <Route path="/asociar-patinadores" element={<ProtectedRoute><AsociarPatinadores /></ProtectedRoute>} />
           <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -72,7 +72,12 @@ export default function Navbar() {
     ? [
         { label: 'Inicio', path: '/home' },
         { label: 'Torneos', path: '/torneos' },
-        ...(rol === 'Tecnico' ? [{ label: 'Entrenamientos', path: '/entrenamientos' }] : []),
+        ...(rol === 'Tecnico'
+          ? [
+              { label: 'Entrenamientos', path: '/entrenamientos' },
+              { label: 'Progresos', path: '/progresos' }
+            ]
+          : []),
         ...(rol === 'Delegado'
           ? [{ label: 'Seguros', path: '/seguros' }]
           : []),

--- a/frontend-auth/src/pages/Progresos.jsx
+++ b/frontend-auth/src/pages/Progresos.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+export default function Progresos() {
+  const [patinadores, setPatinadores] = useState([]);
+  const [patinadorId, setPatinadorId] = useState('');
+  const [descripcion, setDescripcion] = useState('');
+  const [progresos, setProgresos] = useState([]);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get('/patinadores');
+        setPatinadores(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    cargar();
+  }, []);
+
+  const cargarProgresos = async (id) => {
+    if (!id) return;
+    try {
+      const res = await api.get(`/progresos/${id}`);
+      setProgresos(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const manejarCambioPatinador = (e) => {
+    const id = e.target.value;
+    setPatinadorId(id);
+    setDescripcion('');
+    cargarProgresos(id);
+  };
+
+  const enviar = async () => {
+    if (!patinadorId || !descripcion) return;
+    try {
+      await api.post('/progresos', { patinador: patinadorId, descripcion });
+      window.dispatchEvent(new Event('notificationsUpdated'));
+      setDescripcion('');
+      await cargarProgresos(patinadorId);
+      alert('Progreso registrado');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Progresos</h1>
+      <div className="mb-3">
+        <label className="form-label">Patinador</label>
+        <select className="form-select" value={patinadorId} onChange={manejarCambioPatinador}>
+          <option value="">Seleccione</option>
+          {patinadores.map((p) => (
+            <option key={p._id} value={p._id}>
+              {p.primerNombre} {p.apellido}
+            </option>
+          ))}
+        </select>
+      </div>
+      {patinadorId && (
+        <>
+          <div className="mb-3">
+            <label className="form-label">Descripción</label>
+            <textarea
+              className="form-control"
+              value={descripcion}
+              onChange={(e) => setDescripcion(e.target.value)}
+            />
+          </div>
+          <button className="btn btn-primary mb-3" onClick={enviar}>
+            Guardar
+          </button>
+          <ul className="list-group">
+            {progresos.map((p) => (
+              <li key={p._id} className="list-group-item">
+                <strong>{new Date(p.fecha).toLocaleDateString('es-AR')}:</strong> {p.descripcion}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add progress model and endpoints for técnicos
- notify associated users about new progress
- add progress page and navigation for técnicos

## Testing
- `npm test` (backend-auth)
- `npm run lint` (frontend-auth)
- `npm test` (frontend-auth) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b266e6e2f48320b4835e9315fc3dfd