### PR TITLE
Add report viewing section and targeted notifications

### DIFF
--- a/backend-auth/models/Notification.js
+++ b/backend-auth/models/Notification.js
@@ -6,6 +6,7 @@ const notificationSchema = new mongoose.Schema(
     mensaje: { type: String, required: true },
     leido: { type: Boolean, default: false },
     competencia: { type: mongoose.Schema.Types.ObjectId, ref: 'Competencia' },
+    progreso: { type: mongoose.Schema.Types.ObjectId, ref: 'Progreso' },
     estadoRespuesta: {
       type: String,
       enum: ['Pendiente', 'Participo', 'No Participo'],

--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -24,6 +24,8 @@ import RankingTorneo from './pages/RankingTorneo';
 import VerNoticia from './pages/VerNoticia';
 import Entrenamientos from './pages/Entrenamientos';
 import Progresos from './pages/Progresos';
+import Reportes from './pages/Reportes';
+import VerReporte from './pages/VerReporte';
 
 function AdminRoute({ children }) {
   const token = localStorage.getItem('token');
@@ -87,6 +89,14 @@ function AppRoutes() {
           <Route
             path="/progresos"
             element={<ProtectedRoute roles={['Tecnico']}><Progresos /></ProtectedRoute>}
+          />
+          <Route
+            path="/reportes"
+            element={<ProtectedRoute roles={['Delegado', 'Deportista']}><Reportes /></ProtectedRoute>}
+          />
+          <Route
+            path="/reportes/:id"
+            element={<ProtectedRoute roles={['Delegado', 'Deportista']}><VerReporte /></ProtectedRoute>}
           />
           <Route path="/asociar-patinadores" element={<ProtectedRoute><AsociarPatinadores /></ProtectedRoute>} />
           <Route path="/admin" element={<AdminRoute><PanelAdmin /></AdminRoute>} />

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -78,6 +78,9 @@ export default function Navbar() {
               { label: 'Progresos', path: '/progresos' }
             ]
           : []),
+        ...(rol === 'Delegado' || rol === 'Deportista'
+          ? [{ label: 'Reportes', path: '/reportes' }]
+          : []),
         ...(rol === 'Delegado'
           ? [{ label: 'Seguros', path: '/seguros' }]
           : []),

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api from '../api';
 
 export default function Notificaciones() {
   const [notificaciones, setNotificaciones] = useState([]);
+  const navigate = useNavigate();
 
   const cargar = async () => {
     try {
@@ -45,6 +47,19 @@ export default function Notificaciones() {
     }
   };
 
+  const verReporte = async (notif) => {
+    try {
+      await api.put(`/notifications/${notif._id}/read`);
+      setNotificaciones((prev) =>
+        prev.map((n) => (n._id === notif._id ? { ...n, leido: true } : n))
+      );
+      window.dispatchEvent(new Event('notificationsUpdated'));
+      navigate(`/reportes/${notif.progreso}`);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   if (notificaciones.length === 0) {
     return (
       <div className="container mt-4 text-black fw-normal">
@@ -61,7 +76,17 @@ export default function Notificaciones() {
         {notificaciones.map((n) => (
           <li key={n._id} className={`list-group-item ${n.leido ? '' : 'list-group-item-warning'}`}>
             <div className="d-flex justify-content-between align-items-center">
-              <span className="text-black fw-normal">{n.mensaje}</span>
+              {n.progreso ? (
+                <span
+                  className="text-black fw-normal"
+                  style={{ cursor: 'pointer', textDecoration: 'underline' }}
+                  onClick={() => verReporte(n)}
+                >
+                  {n.mensaje}
+                </span>
+              ) : (
+                <span className="text-black fw-normal">{n.mensaje}</span>
+              )}
               {n.competencia && n.estadoRespuesta !== 'Pendiente' && (
                 <span className="badge bg-secondary">{n.estadoRespuesta}</span>
               )}
@@ -82,7 +107,7 @@ export default function Notificaciones() {
                 </button>
               </div>
             )}
-            {!n.competencia && !n.leido && (
+            {!n.competencia && !n.progreso && !n.leido && (
               <div className="mt-2">
                 <button className="btn btn-sm btn-primary" onClick={() => marcarLeida(n._id)}>
                   Marcar como leída

--- a/frontend-auth/src/pages/Reportes.jsx
+++ b/frontend-auth/src/pages/Reportes.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+export default function Reportes() {
+  const [patinadores, setPatinadores] = useState([]);
+  const [patinadorId, setPatinadorId] = useState('');
+  const [progresos, setProgresos] = useState([]);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get('/protegido/usuario');
+        setPatinadores(res.data.usuario.patinadores || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    cargar();
+  }, []);
+
+  const cargarProgresos = async (id) => {
+    if (!id) return;
+    try {
+      const res = await api.get(`/progresos/${id}`);
+      setProgresos(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const manejarCambio = (e) => {
+    const id = e.target.value;
+    setPatinadorId(id);
+    cargarProgresos(id);
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Reportes</h1>
+      <div className="mb-3">
+        <label className="form-label">Patinador</label>
+        <select className="form-select" value={patinadorId} onChange={manejarCambio}>
+          <option value="">Seleccione</option>
+          {patinadores.map((p) => (
+            <option key={p._id} value={p._id}>
+              {p.primerNombre} {p.apellido}
+            </option>
+          ))}
+        </select>
+      </div>
+      {patinadorId && (
+        progresos.length > 0 ? (
+          <ul className="list-group">
+            {progresos.map((p) => (
+              <li key={p._id} className="list-group-item">
+                <strong>{new Date(p.fecha).toLocaleDateString('es-AR')}:</strong> {p.descripcion}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No hay reportes para este patinador.</p>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/VerReporte.jsx
+++ b/frontend-auth/src/pages/VerReporte.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+
+export default function VerReporte() {
+  const { id } = useParams();
+  const [reporte, setReporte] = useState(null);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get(`/progreso/${id}`);
+        setReporte(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    cargar();
+  }, [id]);
+
+  if (!reporte) {
+    return (
+      <div className="container mt-4">
+        <p>Cargando...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">
+        Reporte de {reporte.patinador.primerNombre} {reporte.patinador.apellido}
+      </h1>
+      <p>
+        <strong>Fecha:</strong> {new Date(reporte.fecha).toLocaleDateString('es-AR')}
+      </p>
+      <p>
+        <strong>Descripción:</strong>
+      </p>
+      <p>{reporte.descripcion}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `progreso` reference in notifications and send report alerts only to relevant user
- Provide endpoint to fetch individual progress reports
- Introduce report viewing pages and link notifications to specific reports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b26ceed1bc8320a1dcca01179cc630