### PR TITLE
Fix progress report notification recipient

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1469,7 +1469,10 @@ app.post('/api/progresos/:id/enviar', protegerRuta, permitirRol('Tecnico'), asyn
     if (prog.enviado) {
       return res.status(400).json({ mensaje: 'Progreso ya enviado' });
     }
-    const usuario = await User.findOne({ patinadores: prog.patinador._id });
+    const usuario = await User.findOne({
+      patinadores: prog.patinador._id,
+      rol: 'Deportista'
+    });
     const mensaje = `Nuevo progreso de ${prog.patinador.primerNombre} ${prog.patinador.apellido}`;
     if (usuario) {
       await Notification.create({


### PR DESCRIPTION
## Summary
- Ensure progress report notifications are sent to the user associated with the skater instead of the reporting coach

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27175d4a08320855f4d262d16e0a6