### PR TITLE
Add map link to address in footer

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -70,7 +70,15 @@ export default function Footer() {
                 <i className="bi bi-envelope me-2"></i> patincarreragr25@gmail.com
               </li>
               <li className="mb-2">
-                <i className="bi bi-geo-alt me-2"></i> Leandro N. Alem, B1748 Gran Buenos Aires, Provincia de Buenos Aires
+                <i className="bi bi-geo-alt me-2"></i>
+                <a
+                  href="https://maps.app.goo.gl/t7Wb4ci6P9zZrtGB8"
+                  className="text-light text-decoration-none"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Leandro N. Alem, B1748 Gran Buenos Aires, Provincia de Buenos Aires
+                </a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- make footer address link to Google Maps

## Testing
- `npm test` (frontend-auth) *(fails: Missing script: "test")*
- `npm run lint` (frontend-auth)
- `npm test` (backend-auth)


------
https://chatgpt.com/codex/tasks/task_e_68b31b0eb6f8832086cc09f9d4e3ab91