### PR TITLE
feat: add contact endpoint and use user info

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -274,6 +274,34 @@ app.post('/api/auth/login', async (req, res) => {
   }
 });
 
+app.post('/api/contacto', protegerRuta, async (req, res) => {
+  const { mensaje } = req.body;
+  if (!mensaje) {
+    return res.status(400).json({ mensaje: 'Mensaje requerido' });
+  }
+  try {
+    const usuario = await User.findById(req.usuario.id).select('nombre email');
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS
+      }
+    });
+    await transporter.sendMail({
+      from: `"${usuario.nombre}" <${usuario.email}>`,
+      to: process.env.EMAIL_USER,
+      subject: 'Nuevo mensaje de contacto',
+      text: mensaje,
+      html: `<p>${mensaje}</p>`
+    });
+    res.json({ mensaje: 'Mensaje enviado' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error al enviar el mensaje' });
+  }
+});
+
 app.get('/api/protegido/usuario', protegerRuta, async (req, res) => {
   try {
     const usuario = await User.findById(req.usuario.id)

--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -5,8 +5,6 @@ import api from '../api';
 export default function Footer() {
   const [historyVisible, setHistoryVisible] = useState(false);
   const [pinned, setPinned] = useState(false);
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
 
   const togglePinned = () => {
@@ -27,13 +25,9 @@ export default function Footer() {
     e.preventDefault();
     try {
       await api.post('/contacto', {
-        nombre: name,
-        email,
         mensaje: message
       });
       alert('Mensaje enviado');
-      setName('');
-      setEmail('');
       setMessage('');
     } catch (err) {
       console.error(err);
@@ -132,26 +126,6 @@ export default function Footer() {
           <div className="col-md-3 mb-4">
             <h5>Contacto</h5>
             <form onSubmit={handleSubmit}>
-              <div className="mb-2">
-                <input
-                  type="text"
-                  className="form-control"
-                  placeholder="Nombre"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  required
-                />
-              </div>
-              <div className="mb-2">
-                <input
-                  type="email"
-                  className="form-control"
-                  placeholder="Email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                />
-              </div>
               <div className="mb-2">
                 <textarea
                   className="form-control"


### PR DESCRIPTION
## Summary
- add /api/contacto endpoint that emails club from logged user's name and email
- simplify footer contact form to send authenticated messages

## Testing
- `npm test` (backend-auth)
- `npm test` (frontend-auth) *(fails: Missing script "test")*
- `npm run lint` (frontend-auth)


------
https://chatgpt.com/codex/tasks/task_e_68b3205863c08320ad296a69934a101b