### PR TITLE
Send footer contact messages to designated email

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -290,7 +290,7 @@ app.post('/api/contacto', protegerRuta, async (req, res) => {
     });
     await transporter.sendMail({
       from: `"${usuario.nombre}" <${usuario.email}>`,
-      to: process.env.EMAIL_USER,
+      to: 'patincarreragr25@gmail.com',
       subject: 'Nuevo mensaje de contacto',
       text: mensaje,
       html: `<p>${mensaje}</p>`


### PR DESCRIPTION
## Summary
- route contact form messages to patincarreragr25@gmail.com

## Testing
- `cd backend-auth && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3238fb89c8320bbe4f9cf739549ab