### PR TITLE
Add club details and club ranking view to tournaments

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -21,6 +21,7 @@ import ListaBuenaFe from './pages/ListaBuenaFe';
 import ResultadosCompetencia from './pages/ResultadosCompetencia';
 import SolicitarSeguro from './pages/SolicitarSeguro';
 import RankingTorneo from './pages/RankingTorneo';
+import RankingClubes from './pages/RankingClubes';
 import VerNoticia from './pages/VerNoticia';
 import Entrenamientos from './pages/Entrenamientos';
 import Progresos from './pages/Progresos';
@@ -47,6 +48,10 @@ function AppRoutes() {
           <Route
             path="/torneos/:id/ranking"
             element={<ProtectedRoute><RankingTorneo /></ProtectedRoute>}
+          />
+          <Route
+            path="/torneos/:id/ranking-clubes"
+            element={<ProtectedRoute><RankingClubes /></ProtectedRoute>}
           />
           <Route
             path="/competencias/:id/lista"

--- a/frontend-auth/src/pages/RankingClubes.jsx
+++ b/frontend-auth/src/pages/RankingClubes.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+
+export default function RankingClubes() {
+  const { id } = useParams();
+  const [clubes, setClubes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const res = await api.get(`/tournaments/${id}/ranking/club`);
+        setClubes(res.data);
+      } catch (err) {
+        console.error(err);
+        setError('Error al cargar ranking de clubes');
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargar();
+  }, [id]);
+
+  if (loading) return <div className="container mt-3">Cargando ranking...</div>;
+  if (error) return <div className="container mt-3 text-danger">{error}</div>;
+
+  return (
+    <div className="container mt-3">
+      <h2>Ranking de Clubes</h2>
+      {clubes.length === 0 ? (
+        <p>No hay datos.</p>
+      ) : (
+        <ul className="list-group">
+          {clubes.map((c, idx) => (
+            <li key={c.club._id} className="list-group-item d-flex justify-content-between">
+              <span>{idx + 1}. {c.club.nombre}</span>
+              <span>{c.puntos}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend-auth/src/pages/RankingTorneo.jsx
+++ b/frontend-auth/src/pages/RankingTorneo.jsx
@@ -5,19 +5,14 @@ import api from '../api';
 export default function RankingTorneo() {
   const { id } = useParams();
   const [individual, setIndividual] = useState([]);
-  const [clubes, setClubes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     const cargar = async () => {
       try {
-        const [resInd, resClub] = await Promise.all([
-          api.get(`/tournaments/${id}/ranking/individual`),
-          api.get(`/tournaments/${id}/ranking/club`)
-        ]);
-        setIndividual(resInd.data);
-        setClubes(resClub.data);
+        const res = await api.get(`/tournaments/${id}/ranking/individual`);
+        setIndividual(res.data);
       } catch (err) {
         console.error(err);
         setError('Error al cargar ranking');
@@ -48,7 +43,7 @@ export default function RankingTorneo() {
                   className="list-group-item d-flex justify-content-between"
                 >
                   <span>
-                    {idx + 1}. {p.nombre}
+                    {idx + 1}. {p.nombre} - {p.club ? p.club.nombre : 'Sin club'}
                   </span>
                   <span>{p.puntos}</span>
                 </li>
@@ -56,24 +51,6 @@ export default function RankingTorneo() {
             </ul>
           </div>
         ))
-      )}
-      <h4>Ranking por Club</h4>
-      {clubes.length === 0 ? (
-        <p>No hay datos.</p>
-      ) : (
-        <ul className="list-group">
-          {clubes.map((c, idx) => (
-            <li
-              key={c.club._id}
-              className="list-group-item d-flex justify-content-between"
-            >
-              <span>
-                {idx + 1}. {c.club.nombre}
-              </span>
-              <span>{c.puntos}</span>
-            </li>
-          ))}
-        </ul>
       )}
     </div>
   );

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -152,6 +152,12 @@ export default function Torneos() {
                 >
                   Ranking
                 </button>
+                <button
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => navigate(`/torneos/${t._id}/ranking-clubes`)}
+                >
+                  Ranking Clubes
+                </button>
                 {rol === 'Delegado' && (
                   <>
                     <button


### PR DESCRIPTION
## Summary
- show each skater's club in individual tournament rankings
- add standalone club ranking page and navigation button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b430f1f530832084830760eacafc01