### PR TITLE
Shift robot left for clearer history bubble

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -49,7 +49,7 @@ export default function Footer() {
         <div className="row align-items-center mb-4">
           <div className="col-md-9 d-flex justify-content-center mb-4 mb-md-0">
             <div
-              className="robot-container"
+              className={`robot-container ${historyVisible ? 'shift-left' : ''}`}
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}
               onClick={togglePinned}
@@ -60,7 +60,7 @@ export default function Footer() {
                 alt="Logo"
                 width="400"
                 height="400"
-                className={`robot-image mb-3 ${historyVisible ? 'shift-left' : ''}`}
+                className="robot-image mb-3"
               />
               {historyVisible && (
                 <div className="history-bubble">

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -591,10 +591,11 @@ body.dark-mode .btn-primary {
 /* Footer styles */
 .history-bubble {
   position: absolute;
-  top: 0;
+  top: 50%;
   left: 100%;
+  transform: translateY(-50%);
   margin-left: 10px;
-  width: 220px;
+  width: 350px;
   background-color: #fff;
   color: #000;
   padding: 0.75rem;
@@ -606,8 +607,9 @@ body.dark-mode .btn-primary {
 .history-bubble::before {
   content: '';
   position: absolute;
-  top: 20px;
+  top: 50%;
   left: -10px;
+  transform: translateY(-50%);
   border-width: 10px;
   border-style: solid;
   border-color: transparent #fff transparent transparent;
@@ -617,14 +619,11 @@ body.dark-mode .btn-primary {
   position: relative;
   display: inline-block;
   width: 400px;
-}
-
-.robot-image {
   transition: transform 0.3s ease;
 }
 
-.robot-image.shift-left {
-  transform: translateX(-150px);
+.robot-container.shift-left {
+  transform: translateX(-200px);
 }
 
 /* Deportista patinador cards */


### PR DESCRIPTION
## Summary
- Move robot container left when showing history bubble
- Center and widen history bubble for readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43d68b3d48320b95a5451a191d490