### PR TITLE
Style footer speech bubble and center links column

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -113,7 +113,7 @@ export default function Footer() {
               </li>
             </ul>
           </div>
-          <div className="col-md-4 mb-4">
+          <div className="col-md-4 mb-4 text-center">
             <h5>Enlaces</h5>
             <ul className="list-unstyled">
               <li>

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -595,11 +595,12 @@ body.dark-mode .btn-primary {
   left: 100%;
   transform: translateY(-50%);
   margin-left: 10px;
-  width: 350px;
+  width: 450px;
   background-color: #fff;
   color: #000;
-  padding: 0.75rem;
-  border-radius: 0.5rem;
+  padding: 1rem;
+  border: 3px solid #000;
+  border-radius: 1.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   z-index: 1000;
 }
@@ -608,9 +609,20 @@ body.dark-mode .btn-primary {
   content: '';
   position: absolute;
   top: 50%;
-  left: -10px;
+  left: -24px;
   transform: translateY(-50%);
-  border-width: 10px;
+  border-width: 16px 24px 16px 0;
+  border-style: solid;
+  border-color: transparent #000 transparent transparent;
+}
+
+.history-bubble::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -20px;
+  transform: translateY(-50%);
+  border-width: 12px 20px 12px 0;
   border-style: solid;
   border-color: transparent #fff transparent transparent;
 }


### PR DESCRIPTION
## Summary
- Expand and restyle footer dialogue into a comic-style speech bubble
- Center the "Enlaces" column within the footer layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43f14b45c832091ba9208b01c7913