### PR TITLE
Ensure full-height pages with sticky footer

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -44,7 +44,7 @@ export default function Footer() {
   };
 
   return (
-    <footer className="footer-custom text-light mt-5">
+    <footer className="footer-custom text-light mt-auto pt-5">
       <div className="container py-5">
         <div className="row align-items-center mb-4">
           <div className="col-md-9 d-flex justify-content-center mb-4 mb-md-0">

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -6,6 +6,12 @@
   --card-bg: #ffffff;
 }
 
+html,
+body,
+#root {
+  min-height: 100vh;
+}
+
 body {
   background-color: var(--bg-color);
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- Guarantee root elements have at least the viewport height
- Allow footer to stick to bottom using auto top margin

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50ba8cf248320b35876613da503db