### PR TITLE
Agregar separación entre formularios y footer

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -38,7 +38,7 @@ function AppRoutes() {
   return (
     <div className="d-flex flex-column min-vh-100">
       <Navbar />
-      <div className="flex-fill">
+      <div className="flex-fill pb-5">
         <Routes>
           <Route path="/" element={<Auth />} />
           <Route path="/home" element={<Home />} />


### PR DESCRIPTION
## Summary
- Añade padding inferior al contenedor principal para separar los formularios del footer

## Testing
- `npm test` (falla: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50dbc39088320a9b6f3261612dc1c