### PR TITLE
feat: implement sticky footer layout

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -38,7 +38,7 @@ function AppRoutes() {
   return (
     <div className="d-flex flex-column min-vh-100">
       <Navbar />
-      <div className="flex-fill pb-5">
+      <main className="flex-fill pb-5">
         <Routes>
           <Route path="/" element={<Auth />} />
           <Route path="/home" element={<Home />} />
@@ -111,7 +111,7 @@ function AppRoutes() {
             element={<ProtectedRoute roles={['Delegado']}><SolicitarSeguro /></ProtectedRoute>}
           />
         </Routes>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -9,7 +9,7 @@
 html,
 body,
 #root {
-  min-height: 100vh;
+  height: 100%;
 }
 
 body {


### PR DESCRIPTION
## Summary
- use `<main>` flex container with auto footer for sticky layout
- ensure root elements stretch to full height for proper flex behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50f97f5f88320b3fa16a52637d544