### PR TITLE
Fix PDF import warning in result parser

### DIFF
--- a/backend-auth/utils/parseResultadosPdf.js
+++ b/backend-auth/utils/parseResultadosPdf.js
@@ -1,7 +1,11 @@
-import pdf from 'pdf-parse/lib/pdf-parse.js';
+// Use default pdf-parse export to ensure built-in configuration
+// that avoids "TT: undefined function" font warnings during parsing.
+import pdf from 'pdf-parse';
 
 export default async function parseResultadosPdf(buffer) {
-  const data = await pdf(buffer);
+  // Parse the entire PDF. Using the packaged parser helps prevent
+  // issues with TrueType fonts that previously triggered warnings.
+  const data = await pdf(buffer, { max: 0 });
   const lines = data.text
     .split(/\r?\n/)
     .map((l) => l.trim())


### PR DESCRIPTION
## Summary
- Use default pdf-parse package instead of internal path and parse all pages
- Add comments explaining removal of TT font warning

## Testing
- `cd backend-auth && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b57bf8d76c8320b484b85fa0b6d59b