### PR TITLE
fix: avoid pdf-parse debug mode in ESM

### DIFF
--- a/backend-auth/utils/parseResultadosPdf.js
+++ b/backend-auth/utils/parseResultadosPdf.js
@@ -1,6 +1,9 @@
-// Use default pdf-parse export to ensure built-in configuration
-// that avoids "TT: undefined function" font warnings during parsing.
-import pdf from 'pdf-parse';
+// Import the underlying pdf-parse implementation directly. The package's
+// root entry file enables a "debug" mode when loaded as an ES module,
+// attempting to read a non-existent test PDF and crashing the server.
+// Importing from "lib/pdf-parse.js" bypasses that behaviour while
+// retaining the default configuration that avoids font warnings.
+import pdf from 'pdf-parse/lib/pdf-parse.js';
 
 export default async function parseResultadosPdf(buffer) {
   // Parse the full PDF using the bundled parser to avoid font warnings.


### PR DESCRIPTION
## Summary
- import pdf-parse implementation directly to prevent debug mode reading non-existent file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59f4e35b083209cb9e5dd4d1f5846