### PR TITLE
Convert competition result PDFs through JSON for storage

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -22,7 +22,8 @@ import Club from './models/Club.js';
 import Entrenamiento from './models/Entrenamiento.js';
 import Progreso from './models/Progreso.js';
 import ExcelJS from 'exceljs';
-import parseResultadosPdf from './utils/parseResultadosPdf.js';
+import pdfToJson from './utils/pdfToJson.js';
+import parseResultadosJson from './utils/parseResultadosJson.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -879,7 +880,8 @@ app.post(
       const buffer = fs.readFileSync(req.file.path);
       fs.unlinkSync(req.file.path);
       const hash = crypto.createHash('md5').update(buffer).digest('hex');
-      const filas = await parseResultadosPdf(buffer);
+      const json = await pdfToJson(buffer);
+      const filas = parseResultadosJson(json);
       let count = 0;
       for (const fila of filas) {
         const patinador = await Patinador.findOne({

--- a/backend-auth/utils/parseResultadosJson.js
+++ b/backend-auth/utils/parseResultadosJson.js
@@ -1,18 +1,5 @@
-// Import the underlying pdf-parse implementation directly. The package's
-// root entry file enables a "debug" mode when loaded as an ES module,
-// attempting to read a non-existent test PDF and crashing the server.
-// Importing from "lib/pdf-parse.js" bypasses that behaviour while
-// retaining the default configuration that avoids font warnings.
-import pdf from 'pdf-parse/lib/pdf-parse.js';
-
-export default async function parseResultadosPdf(buffer) {
-  // Parse the full PDF using the bundled parser to avoid font warnings.
-  const data = await pdf(buffer, { max: 0 });
-  const lines = data.text
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean);
-
+export default function parseResultadosJson(json) {
+  const { lines } = json;
   const results = [];
   let currentCategoria = null;
 

--- a/backend-auth/utils/pdfToJson.js
+++ b/backend-auth/utils/pdfToJson.js
@@ -1,0 +1,10 @@
+import pdf from 'pdf-parse/lib/pdf-parse.js';
+
+export default async function pdfToJson(buffer) {
+  const data = await pdf(buffer, { max: 0 });
+  const lines = data.text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return { lines };
+}


### PR DESCRIPTION
## Summary
- Convert incoming PDF buffers to JSON line arrays with `pdfToJson`
- Parse JSON lines into structured result objects via `parseResultadosJson`
- Update import route to use the JSON intermediary before persisting results

## Testing
- `cd backend-auth && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5a82506608320b1fdec039abbab9d