### PR TITLE
feat: save pdf import as json and return results

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -878,9 +878,10 @@ app.post(
         return res.status(400).json({ mensaje: 'Archivo no proporcionado' });
       }
       const buffer = fs.readFileSync(req.file.path);
+      const jsonPath = req.file.path.replace(/\.[^./]+$/, '.json');
+      const json = await pdfToJson(buffer, jsonPath);
       fs.unlinkSync(req.file.path);
       const hash = crypto.createHash('md5').update(buffer).digest('hex');
-      const json = await pdfToJson(buffer);
       const filas = parseResultadosJson(json);
       let count = 0;
       for (const fila of filas) {
@@ -907,7 +908,12 @@ app.post(
         count++;
       }
       await recalcularPosiciones(competencia._id);
-      res.json({ mensaje: 'Importación completada', procesados: count });
+      res.json({
+        mensaje: 'Importación completada',
+        procesados: count,
+        archivoJson: path.basename(jsonPath),
+        resultados: filas
+      });
     } catch (err) {
       console.error(err);
       res.status(500).json({ mensaje: 'Error al importar resultados' });

--- a/backend-auth/utils/pdfToJson.js
+++ b/backend-auth/utils/pdfToJson.js
@@ -1,10 +1,26 @@
 import pdf from 'pdf-parse/lib/pdf-parse.js';
+import fs from 'fs';
+import path from 'path';
 
-export default async function pdfToJson(buffer) {
+// Convierte el contenido de un PDF a un objeto JSON y opcionalmente lo guarda en disco.
+//
+// buffer: contenido del archivo PDF en memoria.
+// outputPath: ruta donde se guardará el archivo JSON generado. Si se omite, solo devuelve el objeto.
+export default async function pdfToJson(buffer, outputPath) {
   const data = await pdf(buffer, { max: 0 });
   const lines = data.text
     .split(/\r?\n/)
     .map((l) => l.trim())
     .filter(Boolean);
-  return { lines };
+  const json = { lines };
+
+  if (outputPath) {
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(outputPath, JSON.stringify(json, null, 2));
+  }
+
+  return json;
 }


### PR DESCRIPTION
## Summary
- write PDF parsing utility that optionally saves JSON to disk
- enhance competition results import route to persist JSON and return parsed rows

## Testing
- `npm test`
- `cd ../frontend-auth && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5aded3ca483209fd8140e57120641