### PR TITLE
Silence pdf.js warnings during PDF parsing

### DIFF
--- a/backend-auth/utils/pdfToJson.js
+++ b/backend-auth/utils/pdfToJson.js
@@ -1,6 +1,11 @@
 import pdf from 'pdf-parse/lib/pdf-parse.js';
+import pdfjs from 'pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js';
 import fs from 'fs';
 import path from 'path';
+
+// Reducimos la verbosidad de pdf.js para evitar advertencias como
+// "TT: undefined function" que se muestran en consola al procesar algunos PDF.
+pdfjs.setVerbosityLevel(pdfjs.VerbosityLevel.ERRORS);
 
 // Convierte el contenido de un PDF a un objeto JSON y opcionalmente lo guarda en disco.
 //


### PR DESCRIPTION
## Summary
- reduce pdf.js verbosity so warnings like `TT: undefined function` are hidden when parsing PDFs

## Testing
- `cd backend-auth && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b28b27b48320a17f5c7fd2f095bb