### PR TITLE
fix: build default api url from current hostname

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -1,13 +1,12 @@
 import axios from 'axios';
 
-// Axios instance that automatically attaches the JWT token from localStorage
-// Use the API URL from environment variables when available. If it is not
-// provided, fall back to `http://localhost:5000/api` so the frontend
-// connects directly to the backend without relying on Vite's dev proxy.
-// This avoids proxy connection errors when the dev server cannot reach the
-// backend.
+// Axios instance that automatically attaches the JWT token from localStorage.
+// Use the API URL from environment variables when available. If not provided,
+// build a default URL using the current hostname so that the frontend can reach
+// the backend even when it runs on a different machine from the browser.
+const defaultBaseUrl = `http://${window.location.hostname}:5000/api`;
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api'
+  baseURL: import.meta.env.VITE_API_URL || defaultBaseUrl
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- compute default API base URL from current hostname

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5b696d9a88320a7fdd941426f2029