### PR TITLE
Fix default API base URL to match page protocol

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -2,9 +2,12 @@ import axios from 'axios';
 
 // Axios instance that automatically attaches the JWT token from localStorage.
 // Use the API URL from environment variables when available. If not provided,
-// build a default URL using the current hostname so that the frontend can reach
-// the backend even when it runs on a different machine from the browser.
-const defaultBaseUrl = `http://${window.location.hostname}:5000/api`;
+// build a default URL using the current page's protocol and hostname. This
+// avoids mixed-content errors when the frontend is served over HTTPS by
+// matching the protocol used by the page while still defaulting to port 5000
+// for local development. The port can be overridden via `VITE_BACKEND_PORT`.
+const port = import.meta.env.VITE_BACKEND_PORT || 5000;
+const defaultBaseUrl = `${window.location.protocol}//${window.location.hostname}:${port}/api`;
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || defaultBaseUrl
 });


### PR DESCRIPTION
## Summary
- build default API URL using current page protocol and configurable port

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5bc093530832080e47796af6173e3