### PR TITLE
Handle port conflicts in backend server automatically

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1659,7 +1659,21 @@ app.get('/api/auth/google/callback', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`Servidor escuchando en puerto ${PORT}`);
-});
+const PORT = parseInt(process.env.PORT, 10) || 5000;
+
+function startServer(port) {
+  const server = app.listen(port, () => {
+    console.log(`Servidor escuchando en puerto ${port}`);
+  });
+
+  server.on('error', (err) => {
+    if (err.code === 'EADDRINUSE') {
+      console.warn(`Puerto ${port} en uso, intentando con ${port + 1}...`);
+      startServer(port + 1);
+    } else {
+      throw err;
+    }
+  });
+}
+
+startServer(PORT);


### PR DESCRIPTION
## Summary
- add startServer helper to retry listening on the next port when the default is busy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d171660083208d8d564a91ecd752