### PR TITLE
Configure project for Hostinger deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 frontend-auth/node_modules
 backend-auth/node_modules
 backend-auth/usuarios.db
+.env
+backend-auth/.env
+frontend-auth/.env

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,61 @@
+# Deployment Guide for Hostinger VPS
+
+This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `patincarrera.net`.
+
+## 1. Prepare the Server
+1. Update packages and install dependencies:
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   sudo apt install -y nginx nodejs npm
+   sudo npm install -g pm2
+   ```
+2. Clone the repository on the server:
+   ```bash
+   git clone https://github.com/USER/patincarreraGR.git
+   cd patincarreraGR
+   ```
+
+## 2. Backend Configuration
+1. Create the environment file:
+   ```bash
+   cd backend-auth
+   cp .env.example .env
+   # edit .env with real values (Mongo URI, JWT secret, email creds, etc.)
+   npm install
+   pm2 start server.js --name patincarrera-backend
+   pm2 save
+   cd ..
+   ```
+
+## 3. Frontend Build
+1. Build the React app:
+   ```bash
+   cd frontend-auth
+   cp .env.example .env
+   npm install
+   npm run build
+   sudo mkdir -p /var/www/patincarrera/frontend
+   sudo cp -r dist /var/www/patincarrera/frontend
+   cd ..
+   ```
+
+## 4. Nginx
+1. Copy the provided configuration:
+   ```bash
+   sudo cp deployment/nginx.conf /etc/nginx/sites-available/patincarrera
+   sudo ln -s /etc/nginx/sites-available/patincarrera /etc/nginx/sites-enabled/
+   sudo nginx -t
+   sudo systemctl restart nginx
+   ```
+2. Point the domain DNS records for `patincarrera.net` and `www.patincarrera.net` to the server IP `72.60.62.242`.
+
+## 5. Optional HTTPS
+Use [Certbot](https://certbot.eff.org/) to obtain a Let's Encrypt certificate:
+```bash
+sudo apt install -y certbot python3-certbot-nginx
+sudo certbot --nginx -d patincarrera.net -d www.patincarrera.net
+```
+
+## Notes
+- Update environment variables as needed for production.
+- PM2 will keep the backend running and revive it on reboot (`pm2 startup`).

--- a/backend-auth/.env.example
+++ b/backend-auth/.env.example
@@ -1,0 +1,14 @@
+MONGODB_URI=mongodb://localhost:27017/backend-auth
+JWT_SECRET=change_me
+FRONTEND_URL=https://patincarrera.net
+FRONTEND_URL_WWW=https://www.patincarrera.net
+BACKEND_URL=https://patincarrera.net
+PORT=5000
+CODIGO_DELEGADO=DEL123
+CODIGO_TECNICO=TEC456
+EMAIL_USER=your_email@example.com
+EMAIL_PASS=your_email_password
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_REDIRECT_URI=https://patincarrera.net/api/auth/google/callback
+CLUB_LOCAL=Gral. Rodríguez

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -58,8 +58,15 @@ mongoose
   })
   .catch((err) => console.error('Error conectando a MongoDB:', err.message));
 
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
+const FRONTEND_URL_WWW = process.env.FRONTEND_URL_WWW;
+
 const app = express();
-app.use(cors());
+const corsOptions = {
+  origin: [FRONTEND_URL, FRONTEND_URL_WWW].filter(Boolean),
+  credentials: true
+};
+app.use(cors(corsOptions));
 app.use(express.json());
 if (!fs.existsSync('uploads')) {
   fs.mkdirSync('uploads');
@@ -70,7 +77,6 @@ app.use('/uploads', express.static('uploads'));
 const CODIGO_DELEGADO = process.env.CODIGO_DELEGADO || 'DEL123';
 const CODIGO_TECNICO = process.env.CODIGO_TECNICO || 'TEC456';
 const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
-const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5000';
 const CLUB_LOCAL = process.env.CLUB_LOCAL || 'Gral. Rodríguez';
 

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name patincarrera.net www.patincarrera.net;
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:5000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    root /var/www/patincarrera/frontend/dist;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend-auth/.env.example
+++ b/frontend-auth/.env.example
@@ -1,1 +1,2 @@
-VITE_API_URL=http://localhost:5000/api
+VITE_API_URL=https://patincarrera.net/api
+# VITE_BACKEND_PORT=5000


### PR DESCRIPTION
## Summary
- limit API CORS to configured frontend domains
- add `.env` templates for backend and frontend
- document VPS setup and provide sample nginx config for patincarrera.net

## Testing
- `cd backend-auth && npm test`
- `cd frontend-auth && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba17c1a7888320a831842e69a22359