### PR TITLE
Handle login for Google accounts without local password

### DIFF
--- a/backend-auth/controllers/authController.js
+++ b/backend-auth/controllers/authController.js
@@ -72,6 +72,15 @@ export const loginUsuario = async (req, res) => {
       return res.status(403).json({ mensaje: 'Tenés que confirmar tu cuenta primero' });
     }
 
+    if (!usuario.password) {
+      return res
+        .status(400)
+        .json({
+          mensaje:
+            'Este usuario se registró con Google y no tiene una contraseña local. Iniciá sesión con Google.'
+        });
+    }
+
     const passwordValido = await bcrypt.compare(password, usuario.password);
     if (!passwordValido) {
       return res.status(401).json({ mensaje: 'Contraseña incorrecta' });

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -260,6 +260,12 @@ app.post('/api/auth/login', async (req, res) => {
     if (!usuario.confirmado) {
       return res.status(403).json({ mensaje: 'Tenés que confirmar tu cuenta primero' });
     }
+    if (!usuario.password) {
+      return res.status(400).json({
+        mensaje:
+          'Este usuario se registró con Google y no tiene una contraseña local. Iniciá sesión con Google.'
+      });
+    }
     const valido = bcrypt.compareSync(password, usuario.password);
     if (!valido) {
       return res.status(400).json({ mensaje: 'Credenciales inválidas' });


### PR DESCRIPTION
## Summary
- Avoid login crashes for users registered with Google but without a local password

## Testing
- `cd backend-auth && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd04553ad8832088a24e77cafd6d01