### PR TITLE
fix: preserve api path for axios calls

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -32,6 +32,14 @@ api.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+  // Ensure request URLs are relative so the `/api` prefix in `baseURL` is
+  // preserved. Axios will drop the path portion of `baseURL` when the request
+  // `url` starts with `/`, leading to requests like
+  // `https://api.example.com/auth/login` instead of
+  // `https://api.example.com/api/auth/login`.
+  if (config.url?.startsWith('/')) {
+    config.url = config.url.slice(1);
+  }
   return config;
 });
 


### PR DESCRIPTION
## Summary
- ensure Axios requests keep `/api` prefix by stripping leading slashes from request URLs
- document reason for removing leading slashes in request interceptor

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd425164d8832097e6a03b7039950a