### PR TITLE
Handle large patinador uploads with proper CORS

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -78,7 +78,16 @@ const allowedOrigins = [
 
 const app = express();
 app.use(cors({ origin: allowedOrigins, credentials: true }));
-app.use(express.json());
+// Allow larger JSON and URL-encoded payloads so image data can be uploaded
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+// Ensure CORS headers are present even when the body exceeds the limit
+app.use((err, req, res, next) => {
+  if (err?.type === 'entity.too.large') {
+    return res.status(413).json({ message: 'Payload too large' });
+  }
+  next(err);
+});
 if (!fs.existsSync('uploads')) {
   fs.mkdirSync('uploads');
 }


### PR DESCRIPTION
## Summary
- allow larger JSON and form payloads in Express server
- send consistent CORS headers and friendly message when payload exceeds limit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c22b85393c8320a9e331ed57b0346d