### PR TITLE
Handle CORS headers when payloads are too large

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -77,13 +77,20 @@ const allowedOrigins = [
 ].filter(Boolean);
 
 const app = express();
-app.use(cors({ origin: allowedOrigins, credentials: true }));
+const corsOptions = { origin: allowedOrigins, credentials: true };
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
 // Allow larger JSON and URL-encoded payloads so image data can be uploaded
-app.use(express.json({ limit: '50mb' }));
-app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+app.use(express.json({ limit: '100mb' }));
+app.use(express.urlencoded({ extended: true, limit: '100mb' }));
 // Ensure CORS headers are present even when the body exceeds the limit
 app.use((err, req, res, next) => {
   if (err?.type === 'entity.too.large') {
+    const origin = req.headers.origin?.replace(/\/+$/, '');
+    if (allowedOrigins.includes(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
     return res.status(413).json({ message: 'Payload too large' });
   }
   next(err);


### PR DESCRIPTION
## Summary
- allow CORS preflight requests and raise request body limits
- return `Access-Control-Allow-Origin` headers even when JSON bodies exceed size limit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c23c38f4888320bb58491691cc1477