### PR TITLE
fix: ensure Google OAuth callback uses HTTPS

### DIFF
--- a/backend-auth/config/passport.js
+++ b/backend-auth/config/passport.js
@@ -6,8 +6,10 @@ require('dotenv').config(); // ← ¡Esto es clave si estás probando passport p
 passport.use(new GoogleStrategy({
   clientID: process.env.GOOGLE_CLIENT_ID,
   clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-  callbackURL: "http://localhost:5000/api/auth/google/callback"
-  
+  callbackURL:
+    process.env.GOOGLE_REDIRECT_URI ||
+    'https://patincarrera.net/api/auth/google/callback'
+
 }, async (accessToken, refreshToken, profile, done) => {
   try {
     const existingUser = await User.findOne({ googleId: profile.id });

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1649,7 +1649,8 @@ app.get('/api/progreso/:id', protegerRuta, async (req, res) => {
 // Inicio de sesión con Google (OAuth 2.0 sin dependencias externas)
 app.get('/api/auth/google', (req, res) => {
   const redirectUri =
-    process.env.GOOGLE_REDIRECT_URI || 'http://patincarrera.net/api/auth/google/callback';
+    process.env.GOOGLE_REDIRECT_URI ||
+    'https://patincarrera.net/api/auth/google/callback';
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID || '',
     redirect_uri: redirectUri,
@@ -1670,7 +1671,8 @@ app.get('/api/auth/google/callback', async (req, res) => {
   }
   try {
     const redirectUri =
-      process.env.GOOGLE_REDIRECT_URI || 'http://patincarrera.net/api/auth/google/callback';
+      process.env.GOOGLE_REDIRECT_URI ||
+      'https://patincarrera.net/api/auth/google/callback';
     const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
## Summary
- use HTTPS production URL as default Google OAuth redirect
- wire same default into Passport strategy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b5ada7008320bec48e9f873dd30c