### PR TITLE
Remove Noticias title from news panel

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -92,7 +92,6 @@ export default function Home() {
         </div>
       )}
       <div className="container mt-4">
-        <h1 className="mb-4">Noticias</h1>
         <div className="news-grid">
           {displayedNews[0] && (
             <Link


### PR DESCRIPTION
## Summary
- remove top "Noticias" title from Home page news section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2bd8e31b48320baa26e1ef3848b0b