### PR TITLE
fix: set default frontend URL for Google OAuth

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -67,8 +67,16 @@ const DEFAULT_ALLOWED_ORIGINS = [
   'https://www.patincarrera.net'
 ].map((url) => url.replace(/\/+$/, ''));
 
-const FRONTEND_URL = process.env.FRONTEND_URL?.replace(/\/+$/, '');
-const FRONTEND_URL_WWW = process.env.FRONTEND_URL_WWW?.replace(/\/+$/, '');
+// Provide sensible defaults for frontend URLs so redirects don't point to
+// `/undefined/...` when environment variables are missing. This keeps Google
+// OAuth working out of the box in production deployments where these variables
+// might not be explicitly defined.
+const FRONTEND_URL = (
+  process.env.FRONTEND_URL || 'https://patincarrera.net'
+).replace(/\/+$/, '');
+const FRONTEND_URL_WWW = (
+  process.env.FRONTEND_URL_WWW || 'https://www.patincarrera.net'
+).replace(/\/+$/, '');
 
 const allowedOrigins = [
   ...DEFAULT_ALLOWED_ORIGINS,


### PR DESCRIPTION
## Summary
- default to patincarrera.net URLs when `FRONTEND_URL` vars are absent to ensure OAuth redirects function

## Testing
- `cd backend-auth && npm test`
- `cd ../frontend-auth && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2e1a8f8e08320a4b5b590ef869c6e