### PR TITLE
Fix Hostinger static build deployment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -34,8 +34,12 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    cp .env.example .env
    npm install
    npm run build
-   sudo mkdir -p /var/www/patincarrera/frontend
-   sudo cp -r dist /var/www/patincarrera/frontend
+   sudo mkdir -p /var/www/patincarrera/frontend/dist
+   # Copy the *contents* of the Vite build so the document root has an index.html
+   # directly inside it. Leaving the files nested inside an extra `dist/`
+   # directory causes Nginx/Hostinger to respond with "403 Forbidden" because
+   # there is no index at the root level.
+   sudo rsync -a dist/ /var/www/patincarrera/frontend/dist/
    cd ..
    ```
 

--- a/frontend-auth/vite.config.js
+++ b/frontend-auth/vite.config.js
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Use relative asset paths so the build works even when it's deployed inside
+  // a subdirectory (e.g. Hostinger's `public_html/dist` during manual uploads).
+  // Without this setting the generated HTML points to `/assets/...`, which
+  // fails with 404 errors when the site isn't served from the domain root.
+  base: './',
   plugins: [react()],
   // Proxy only uploaded files during development. API requests now use an
   // absolute backend URL defined in `src/api.js`, which avoids development


### PR DESCRIPTION
## Summary
- configure the Vite build to emit relative asset URLs so it works when uploaded into a subdirectory on Hostinger
- clarify the deployment guide to copy the built files directly into the web root, avoiding 403 errors from missing index pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb00ea40b48320ac1c15b3c63737d8