### PR TITLE
Adjust login page heading

### DIFF
--- a/frontend-auth/src/pages/Auth.jsx
+++ b/frontend-auth/src/pages/Auth.jsx
@@ -10,7 +10,7 @@ export default function Auth() {
       <div className="row justify-content-center">
         <div className="col-12 col-md-6">
           <h1 className="text-center mb-4">
-            {mostrarRegistro ? 'Registrarse' : 'Patín Carrera'}
+            {mostrarRegistro ? 'Registrarse' : 'Patin carrera General Rodriguez'}
           </h1>
           <div className="card p-4">
             {mostrarRegistro ? <RegisterForm /> : <LoginForm />}


### PR DESCRIPTION
## Summary
- update the Auth page heading to display "Patin carrera General Rodriguez" on the login screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd2db2114c8320a1ed87daab9107f2