### PR TITLE
Add dotenv config import to server entrypoint

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import bcrypt from 'bcryptjs';


### PR DESCRIPTION
## Summary
- import dotenv/config at the top of backend-auth/server.js so environment variables load when the server starts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd9df284a08320bcbcc8ab07cb7fd2