### PR TITLE
Fix backend boot failure when dotenv package is absent

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import bcrypt from 'bcryptjs';


### PR DESCRIPTION
## Summary
- remove the unused `dotenv/config` import from the backend server entrypoint to avoid requiring an unlisted dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde8f65b54832087fd9d9678e59777