### PR TITLE
Handle missing credentials in login routes

### DIFF
--- a/backend-auth/controllers/authController.js
+++ b/backend-auth/controllers/authController.js
@@ -68,11 +68,15 @@ export const confirmarCuenta = async (req, res) => {
 // Login de usuario
 export const loginUsuario = async (req, res) => {
   try {
-    const { email, password } = req.body;
+    const { email, password } = req.body ?? {};
     const emailNormalizado = normalizarEmail(email);
 
     if (!emailNormalizado) {
       return res.status(400).json({ mensaje: 'Email inválido' });
+    }
+
+    if (typeof password !== 'string' || password.trim() === '') {
+      return res.status(400).json({ mensaje: 'Contraseña inválida' });
     }
 
     const usuario = await User.findOne({ email: emailNormalizado });

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -361,10 +361,14 @@ async function crearNotificacionesParaTodos(mensaje, competencia = null) {
 
   const handleLogin = async (req, res) => {
     try {
-      const { email, password } = req.body;
+      const { email, password } = req.body ?? {};
       const emailNormalizado = normalizarEmail(email);
       if (!emailNormalizado) {
         return res.status(400).json({ mensaje: 'Email inválido' });
+      }
+
+      if (typeof password !== 'string' || password.trim() === '') {
+        return res.status(400).json({ mensaje: 'Contraseña inválida' });
       }
 
       const usuario = await User.findOne({ email: emailNormalizado });


### PR DESCRIPTION
## Summary
- avoid destructuring errors in login handlers by defaulting to an empty body
- validate that a non-empty password string is provided before attempting authentication

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdee06667c83209f74ef8402a1abfa