### PR TITLE
Fix local API base URL fallback and alias competencias route

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -987,7 +987,7 @@ app.post(
   }
 );
 
-app.get('/api/competencias', async (req, res) => {
+app.get(['/api/competencias', '/competencias'], async (req, res) => {
   try {
     const comps = await Competencia.find().sort({ fecha: 1 });
     res.json(comps);


### PR DESCRIPTION
## Summary
- ensure the frontend axios client falls back to the backend port when running on localhost so API calls no longer target the Vite dev server
- expose the competitions listing at both `/api/competencias` and `/competencias` to cover requests that miss the `/api` prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdf5147ee0832086177e5cd24508a4