### PR TITLE
Handle missing file uploads when updating profile photo

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -519,7 +519,15 @@ app.post(
   upload.single('foto'),
   async (req, res) => {
     try {
+      if (!req.file) {
+        return res.status(400).json({ mensaje: 'No se recibió ningún archivo' });
+      }
+
       const user = await User.findById(req.usuario.id);
+      if (!user) {
+        return res.status(404).json({ mensaje: 'Usuario no encontrado' });
+      }
+
       // Use the configured backend URL when returning the uploaded image so the
       // path is valid even when requests are proxied through another host.
       user.foto = `${BACKEND_URL}/api/uploads/${req.file.filename}`;


### PR DESCRIPTION
## Summary
- return explicit errors when the profile photo upload endpoint receives no file or the user no longer exists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce04dd2888832086194f0c335fe835