### PR TITLE
Fix competition response 404 by locating notification by id

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1242,15 +1242,17 @@ app.post(
 );
 
 app.post('/api/competitions/:id/responder', protegerRuta, async (req, res) => {
-  const { participa } = req.body;
+  const { participa, notificationId } = req.body;
   try {
     const competencia = await Competencia.findById(req.params.id);
     if (!competencia) return res.status(404).json({ mensaje: 'Competencia no encontrada' });
     const usuario = await User.findById(req.usuario.id).populate('patinadores');
-    const notif = await Notification.findOne({
-      destinatario: req.usuario.id,
-      competencia: competencia._id
-    });
+    const notif = notificationId
+      ? await Notification.findOne({ _id: notificationId, destinatario: req.usuario.id })
+      : await Notification.findOne({
+          destinatario: req.usuario.id,
+          competencia: competencia._id
+        });
     if (!notif) return res.status(404).json({ mensaje: 'Notificación no encontrada' });
     notif.estadoRespuesta = participa ? 'Participo' : 'No Participo';
     notif.leido = true;

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -33,7 +33,10 @@ export default function Notificaciones() {
 
   const responder = async (competenciaId, notifId, participa) => {
     try {
-      await api.post(`/competitions/${competenciaId}/responder`, { participa });
+      await api.post(`/competitions/${competenciaId}/responder`, {
+        participa,
+        notificationId: notifId
+      });
       setNotificaciones((prev) =>
         prev.map((n) =>
           n._id === notifId


### PR DESCRIPTION
## Summary
- allow the competition response endpoint to look up the notification by its id when provided so it no longer returns 404 for existing invites
- send the notification id from the notifications page when answering a competition invite

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d020000c788320adf374338709e99e