### PR TITLE
Add competition response fallbacks

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1241,7 +1241,15 @@ app.post(
   }
 );
 
-app.post('/api/competitions/:id/responder', protegerRuta, async (req, res) => {
+app.post(
+  [
+    '/api/competitions/:id/responder',
+    '/competitions/:id/responder',
+    '/api/competencias/:id/responder',
+    '/competencias/:id/responder'
+  ],
+  protegerRuta,
+  async (req, res) => {
   const { participa, notificationId } = req.body;
   try {
     const competencia = await Competencia.findById(req.params.id);
@@ -1267,7 +1275,8 @@ app.post('/api/competitions/:id/responder', protegerRuta, async (req, res) => {
     console.error(err);
     res.status(500).json({ mensaje: 'Error al responder' });
   }
-});
+  }
+);
 
 app.get(
   '/api/competitions/:id/lista-buena-fe',

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -32,22 +32,39 @@ export default function Notificaciones() {
   };
 
   const responder = async (competenciaId, notifId, participa) => {
-    try {
-      await api.post(`/competitions/${competenciaId}/responder`, {
-        participa,
-        notificationId: notifId
-      });
-      setNotificaciones((prev) =>
-        prev.map((n) =>
-          n._id === notifId
-            ? { ...n, estadoRespuesta: participa ? 'Participo' : 'No Participo', leido: true }
-            : n
-        )
-      );
-      window.dispatchEvent(new Event('notificationsUpdated'));
-    } catch (err) {
-      console.error(err);
+    const payload = { participa, notificationId: notifId };
+    const endpoints = [
+      `/competitions/${competenciaId}/responder`,
+      `/competencias/${competenciaId}/responder`
+    ];
+
+    let lastError = null;
+    for (const endpoint of endpoints) {
+      try {
+        await api.post(endpoint, payload);
+        lastError = null;
+        break;
+      } catch (err) {
+        lastError = err;
+        if (err.response?.status !== 404) {
+          break;
+        }
+      }
     }
+
+    if (lastError) {
+      console.error(lastError);
+      return;
+    }
+
+    setNotificaciones((prev) =>
+      prev.map((n) =>
+        n._id === notifId
+          ? { ...n, estadoRespuesta: participa ? 'Participo' : 'No Participo', leido: true }
+          : n
+      )
+    );
+    window.dispatchEvent(new Event('notificationsUpdated'));
   };
 
   const verReporte = async (notif) => {


### PR DESCRIPTION
## Summary
- allow the competition response endpoint to be reached through both the English and Spanish URL variants so reverse proxies always match it
- retry competition response actions on the Spanish endpoint from the notifications page when the English URL returns a 404

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d046a93480832087d1729b28458d22