### PR TITLE
Add robust fallbacks for broken media

### DIFF
--- a/frontend-auth/src/assets/image-placeholder.svg
+++ b/frontend-auth/src/assets/image-placeholder.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">Imagen no disponible</title>
+  <desc id="desc">Ilustración genérica utilizada como marcador de posición cuando no hay imagen disponible.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#dfe3e8" />
+      <stop offset="100%" stop-color="#c2c9d1" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="url(#bg)" rx="24" ry="24" />
+  <path
+    d="M120 220h160a12 12 0 0012-12v-56l-48-48-64 72-28-28-44 60a12 12 0 0010 12z"
+    fill="#b0b8c1"
+    opacity="0.8"
+  />
+  <circle cx="156" cy="124" r="28" fill="#b0b8c1" opacity="0.9" />
+  <text x="200" y="260" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="32" fill="#6b7785">
+    Sin imagen
+  </text>
+</svg>

--- a/frontend-auth/src/components/ImageWithFallback.jsx
+++ b/frontend-auth/src/components/ImageWithFallback.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import placeholderImage from '../assets/image-placeholder.svg';
+
+/**
+ * Imagen resiliente que reemplaza la fuente original por un marcador
+ * de posición cuando la petición devuelve 404 u otro error de carga.
+ * También evita bucles infinitos de reintentos.
+ */
+export default function ImageWithFallback({ src, alt, fallback, onError, ...props }) {
+  const resolvedFallback = useMemo(() => {
+    const trimmed = typeof fallback === 'string' ? fallback.trim() : '';
+    return trimmed || placeholderImage;
+  }, [fallback]);
+
+  const [currentSrc, setCurrentSrc] = useState(() => {
+    const trimmed = typeof src === 'string' ? src.trim() : '';
+    return trimmed || resolvedFallback;
+  });
+
+  useEffect(() => {
+    const trimmed = typeof src === 'string' ? src.trim() : '';
+    setCurrentSrc(trimmed || resolvedFallback);
+  }, [src, resolvedFallback]);
+
+  const handleError = (event) => {
+    if (event?.currentTarget) {
+      // Evitar bucles infinitos en navegadores antiguos.
+      event.currentTarget.onerror = null;
+    }
+    if (typeof onError === 'function') {
+      onError(event);
+    }
+    setCurrentSrc((previous) => (previous === resolvedFallback ? previous : resolvedFallback));
+  };
+
+  return (
+    <img
+      {...props}
+      src={currentSrc}
+      alt={alt}
+      onError={handleError}
+    />
+  );
+}
+
+ImageWithFallback.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string.isRequired,
+  fallback: PropTypes.string,
+  onError: PropTypes.func
+};
+
+ImageWithFallback.defaultProps = {
+  src: '',
+  fallback: undefined,
+  onError: undefined
+};

--- a/frontend-auth/src/pages/AsociarPatinadores.jsx
+++ b/frontend-auth/src/pages/AsociarPatinadores.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 export default function AsociarPatinadores() {
   const [dniPadre, setDniPadre] = useState('');
@@ -50,9 +51,11 @@ export default function AsociarPatinadores() {
         const foto = getImageUrl(p.foto);
         return (
           <div className="card patinador-card" key={p._id}>
-            {foto && (
-              <img src={foto} className="card-img-top" alt="foto patinador" />
-            )}
+            <ImageWithFallback
+              src={foto}
+              className="card-img-top"
+              alt={`Foto de ${p.primerNombre} ${p.apellido}`}
+            />
             <div className="card-body">
               <h5 className="card-title">{p.primerNombre} {p.apellido}</h5>
               <p className="card-text"><strong>Categoría:</strong> {p.categoria}</p>

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 export default function Competencias() {
   const { id } = useParams();
@@ -129,7 +130,11 @@ export default function Competencias() {
               <li key={c._id} className="list-group-item d-flex justify-content-between align-items-center">
                 <div className="d-flex align-items-center gap-3">
                   {imagen && (
-                    <img src={imagen} alt="imagen competencia" className="competencia-img" />
+                    <ImageWithFallback
+                      src={imagen}
+                      alt={`Imagen de la competencia ${c.nombre}`}
+                      className="competencia-img"
+                    />
                   )}
                   <div>
                     <strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 export default function Home() {
   const [news, setNews] = useState([]);
@@ -116,9 +117,9 @@ export default function Home() {
               </div>
               {displayedNews[0].imagen && (
                 <div className="top-news-image">
-                  <img
+                  <ImageWithFallback
                     src={getImageUrl(displayedNews[0].imagen)}
-                    alt="imagen noticia"
+                    alt={`Imagen de la noticia ${displayedNews[0].titulo}`}
                   />
                 </div>
               )}
@@ -127,9 +128,10 @@ export default function Home() {
           <div className="patinadores-card top-right">
             {currentPatinador ? (
               <>
-                {currentPatinadorFoto && (
-                  <img src={currentPatinadorFoto} alt="foto patinador" />
-                )}
+                <ImageWithFallback
+                  src={currentPatinadorFoto}
+                  alt={`Foto de ${currentPatinador.primerNombre} ${currentPatinador.apellido}`}
+                />
                 <div className="overlay">
                   <h6>
                     {currentPatinador.primerNombre} {currentPatinador.apellido}
@@ -150,9 +152,9 @@ export default function Home() {
             >
               {displayedNews[1].imagen && (
                 <div className="image-container">
-                  <img
+                  <ImageWithFallback
                     src={getImageUrl(displayedNews[1].imagen)}
-                    alt="imagen noticia"
+                    alt={`Imagen de la noticia ${displayedNews[1].titulo}`}
                   />
                   <div className="news-label">NOTICIA</div>
                   <div className="news-label-line" />
@@ -181,9 +183,9 @@ export default function Home() {
             >
               {displayedNews[2].imagen && (
                 <div className="image-container">
-                  <img
+                  <ImageWithFallback
                     src={getImageUrl(displayedNews[2].imagen)}
-                    alt="imagen noticia"
+                    alt={`Imagen de la noticia ${displayedNews[2].titulo}`}
                   />
                   <div className="news-label">NOTICIA</div>
                   <div className="news-label-line" />
@@ -212,9 +214,9 @@ export default function Home() {
             >
               {displayedNews[3].imagen && (
                 <div className="image-container">
-                  <img
+                  <ImageWithFallback
                     src={getImageUrl(displayedNews[3].imagen)}
-                    alt="imagen noticia"
+                    alt={`Imagen de la noticia ${displayedNews[3].titulo}`}
                   />
                   <div className="news-label">NOTICIA</div>
                   <div className="news-label-line" />
@@ -239,9 +241,9 @@ export default function Home() {
             <div className="news-item bottom-right">
               <div className="image-container">
                 {nextCompetition.imagen && (
-                  <img
+                  <ImageWithFallback
                     src={getImageUrl(nextCompetition.imagen)}
-                    alt="imagen competencia"
+                    alt={`Imagen de la competencia ${nextCompetition.nombre}`}
                   />
                 )}
                 <div className="news-label competition-label">COMPETENCIA</div>
@@ -273,9 +275,9 @@ export default function Home() {
               className="mini-news-card"
             >
               {item.imagen && (
-                <img
+                <ImageWithFallback
                   src={getImageUrl(item.imagen)}
-                  alt="imagen noticia"
+                  alt={`Imagen de la noticia ${item.titulo}`}
                 />
               )}
               <div className="mini-news-info">
@@ -308,9 +310,9 @@ export default function Home() {
               >
                 {item.imagen && (
                   <div className="image-container">
-                    <img
+                    <ImageWithFallback
                       src={getImageUrl(item.imagen)}
-                      alt="imagen noticia"
+                      alt={`Imagen de la noticia ${item.titulo}`}
                     />
                     <div className="news-label">NOTICIA</div>
                     <div className="news-label-line" />
@@ -345,9 +347,9 @@ export default function Home() {
               >
                 {item.imagen && (
                   <div className="image-container">
-                    <img
+                    <ImageWithFallback
                       src={getImageUrl(item.imagen)}
-                      alt="imagen noticia"
+                      alt={`Imagen de la noticia ${item.titulo}`}
                     />
                     <div className="news-label">NOTICIA</div>
                     <div className="news-label-line" />

--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 export default function ListaPatinadores() {
   const [patinadores, setPatinadores] = useState([]);
@@ -62,9 +63,10 @@ export default function ListaPatinadores() {
             const foto = getImageUrl(p.foto);
             return (
               <div className="deportista-card mb-4" key={p._id}>
-                {foto && (
-                  <img src={foto} alt={`${p.primerNombre} ${p.apellido}`} />
-                )}
+                <ImageWithFallback
+                  src={foto}
+                  alt={`${p.primerNombre} ${p.apellido}`}
+                />
                 <div className="category-label">{p.categoria}</div>
                 <div className="category-label-line" />
                 <div className="name-label">
@@ -98,13 +100,11 @@ export default function ListaPatinadores() {
           return (
             <div className="col-md-4 mb-4" key={p._id}>
               <div className="card h-100">
-                {fotoRostro && (
-                  <img
-                    src={fotoRostro}
-                    className="card-img-top"
-                    alt={`${p.primerNombre} ${p.apellido}`}
-                  />
-                )}
+                <ImageWithFallback
+                  src={fotoRostro}
+                  className="card-img-top"
+                  alt={`${p.primerNombre} ${p.apellido}`}
+                />
                 <div className="card-body d-flex flex-column">
                   <h5 className="card-title">
                     {p.primerNombre} {p.apellido}

--- a/frontend-auth/src/pages/VerNoticia.jsx
+++ b/frontend-auth/src/pages/VerNoticia.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 export default function VerNoticia() {
   const { id } = useParams();
@@ -28,9 +29,9 @@ export default function VerNoticia() {
     <div className="container mt-4">
       <h1 className="mb-3">{noticia.titulo}</h1>
       {noticia.imagen && (
-        <img
+        <ImageWithFallback
           src={getImageUrl(noticia.imagen)}
-          alt="imagen noticia"
+          alt={`Imagen de la noticia ${noticia.titulo}`}
           className="img-fluid mb-3"
         />
       )}

--- a/frontend-auth/src/pages/VerPatinador.jsx
+++ b/frontend-auth/src/pages/VerPatinador.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 export default function VerPatinador() {
   const { id } = useParams();
@@ -35,7 +36,7 @@ export default function VerPatinador() {
         {patinador.apellido}
       </h1>
       {patinador.fotoRostro && (
-        <img
+        <ImageWithFallback
           src={getImageUrl(patinador.fotoRostro)}
           alt={`${patinador.primerNombre} ${patinador.apellido}`}
           style={{ maxWidth: '200px' }}
@@ -63,7 +64,7 @@ export default function VerPatinador() {
       </ul>
       {patinador.foto && (
         <div className="mb-3">
-          <img
+          <ImageWithFallback
             src={getImageUrl(patinador.foto)}
             alt={`${patinador.primerNombre} ${patinador.apellido}`}
             className="img-fluid"


### PR DESCRIPTION
## Summary
- add a reusable `ImageWithFallback` component with an SVG placeholder
- swap dynamic `<img>` tags to use the new component across patinador, noticia and competencia views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d08169de548320b3e022f6b9d91da4