### PR TITLE
Add tracked uploads directory

### DIFF
--- a/backend-auth/.gitignore
+++ b/backend-auth/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
-uploads
+uploads/*
+!uploads/README.md

--- a/backend-auth/uploads/README.md
+++ b/backend-auth/uploads/README.md
@@ -1,0 +1,5 @@
+# Carpeta de uploads
+
+Este directorio se utiliza para almacenar las imágenes subidas por los usuarios en tiempo de ejecución.
+
+El contenido de esta carpeta se genera dinámicamente y suele estar vacío en el repositorio, pero se mantiene para garantizar que la estructura necesaria exista en los entornos de despliegue.


### PR DESCRIPTION
## Summary
- add an `uploads` directory under the backend so the runtime image storage path exists by default
- document the purpose of the directory so it remains in the repository
- adjust the backend gitignore to keep the README but ignore uploaded files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0875da02c832087a9b513921802e8