### PR TITLE
Fix uploads directory resolution for static files

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -11,7 +11,7 @@ import mongoose from 'mongoose';
 import User from './models/User.js';
 import Patinador from './models/Patinador.js';
 import { protegerRuta, permitirRol } from './middlewares/authMiddleware.js';
-import upload from './utils/multer.js';
+import upload, { UPLOADS_DIR } from './utils/multer.js';
 import News from './models/News.js';
 import Notification from './models/Notification.js';
 import Torneo from './models/Torneo.js';
@@ -165,10 +165,10 @@ app.use((err, req, res, next) => {
   }
   next(err);
 });
-if (!fs.existsSync('uploads')) {
-  fs.mkdirSync('uploads');
+if (!fs.existsSync(UPLOADS_DIR)) {
+  fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 }
-app.use('/api/uploads', express.static('uploads'));
+app.use('/api/uploads', express.static(UPLOADS_DIR));
 
 
 const CODIGO_DELEGADO = process.env.CODIGO_DELEGADO || 'DEL123';

--- a/backend-auth/utils/multer.js
+++ b/backend-auth/utils/multer.js
@@ -1,16 +1,21 @@
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 
-// Ensure the uploads directory exists so Multer can save files without errors.
-const uploadDir = path.resolve('uploads');
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir, { recursive: true });
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Ensure the uploads directory lives inside the backend folder regardless of the
+// working directory from which the server is started (e.g. via PM2 or Docker).
+export const UPLOADS_DIR = path.resolve(__dirname, '..', 'uploads');
+
+if (!fs.existsSync(UPLOADS_DIR)) {
+  fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 }
 
 const storage = multer.diskStorage({
   destination(req, file, cb) {
-    cb(null, uploadDir);
+    cb(null, UPLOADS_DIR);
   },
   filename(req, file, cb) {
     const ext = path.extname(file.originalname);


### PR DESCRIPTION
## Summary
- ensure the uploads directory path is resolved relative to the backend folder
- reuse the shared uploads path for both Multer storage and Express static hosting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d08e34c8fc8320892823d624f4dae1