### PR TITLE
Alinear rutas de competencias en frontend y backend

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1084,7 +1084,12 @@ app.delete([
 });
 
 app.post(
-  ['/api/tournaments/:id/competitions', '/tournaments/:id/competitions'],
+  [
+    '/api/tournaments/:id/competitions',
+    '/tournaments/:id/competitions',
+    '/api/torneos/:id/competencias',
+    '/torneos/:id/competencias'
+  ],
   protegerRuta,
   permitirRol('Delegado'),
   upload.single('imagen'),
@@ -1126,7 +1131,9 @@ app.get(['/api/competencias', '/competencias'], async (req, res) => {
 
 app.get([
   '/api/tournaments/:id/competitions',
-  '/tournaments/:id/competitions'
+  '/tournaments/:id/competitions',
+  '/api/torneos/:id/competencias',
+  '/torneos/:id/competencias'
 ], protegerRuta, async (req, res) => {
   try {
     const comps = await Competencia.find({ torneo: req.params.id }).sort({ fecha: 1 });
@@ -1138,7 +1145,12 @@ app.get([
 });
 
 app.put(
-  '/api/competitions/:id',
+  [
+    '/api/competitions/:id',
+    '/competitions/:id',
+    '/api/competencias/:id',
+    '/competencias/:id'
+  ],
   protegerRuta,
   permitirRol('Delegado'),
   upload.single('imagen'),
@@ -1162,7 +1174,12 @@ app.put(
   }
 );
 
-app.delete('/api/competitions/:id', protegerRuta, permitirRol('Delegado'), async (req, res) => {
+app.delete([
+  '/api/competitions/:id',
+  '/competitions/:id',
+  '/api/competencias/:id',
+  '/competencias/:id'
+], protegerRuta, permitirRol('Delegado'), async (req, res) => {
   try {
     await Resultado.deleteMany({ competenciaId: req.params.id });
     // Elimina notificaciones no leídas asociadas a la competencia
@@ -1176,7 +1193,12 @@ app.delete('/api/competitions/:id', protegerRuta, permitirRol('Delegado'), async
   }
 });
 
-app.get('/api/competitions/:id/resultados', protegerRuta, async (req, res) => {
+app.get([
+  '/api/competitions/:id/resultados',
+  '/competitions/:id/resultados',
+  '/api/competencias/:id/resultados',
+  '/competencias/:id/resultados'
+], protegerRuta, async (req, res) => {
   try {
     await recalcularPosiciones(req.params.id);
     const resultados = await Resultado.find({ competenciaId: req.params.id })
@@ -1190,7 +1212,12 @@ app.get('/api/competitions/:id/resultados', protegerRuta, async (req, res) => {
 });
 
 app.post(
-  '/api/competitions/:id/resultados/import-pdf',
+  [
+    '/api/competitions/:id/resultados/import-pdf',
+    '/competitions/:id/resultados/import-pdf',
+    '/api/competencias/:id/resultados/import-pdf',
+    '/competencias/:id/resultados/import-pdf'
+  ],
   protegerRuta,
   permitirRol('Delegado'),
   upload.single('archivo'),
@@ -1248,7 +1275,12 @@ app.post(
 );
 
 app.post(
-  '/api/competitions/:id/resultados/manual',
+  [
+    '/api/competitions/:id/resultados/manual',
+    '/competitions/:id/resultados/manual',
+    '/api/competencias/:id/resultados/manual',
+    '/competencias/:id/resultados/manual'
+  ],
   protegerRuta,
   permitirRol('Delegado'),
   async (req, res) => {

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -17,7 +17,7 @@ export default function Competencias() {
   useEffect(() => {
     const cargar = async () => {
       try {
-        const res = await api.get(`/tournaments/${id}/competitions`);
+        const res = await api.get(`/torneos/${id}/competencias`);
         setCompetencias(Array.isArray(res.data) ? res.data : []);
       } catch (err) {
         console.error(err);
@@ -38,7 +38,7 @@ export default function Competencias() {
       if (e.target.imagen.files[0]) {
         formData.append('imagen', e.target.imagen.files[0]);
       }
-      await api.post(`/tournaments/${id}/competitions`, formData, {
+      await api.post(`/torneos/${id}/competencias`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data'
         }
@@ -46,7 +46,7 @@ export default function Competencias() {
       setNombre('');
       setFecha('');
       e.target.imagen.value = '';
-      const res = await api.get(`/tournaments/${id}/competitions`);
+      const res = await api.get(`/torneos/${id}/competencias`);
       setCompetencias(Array.isArray(res.data) ? res.data : []);
     } catch (err) {
       console.error(err);
@@ -60,11 +60,11 @@ export default function Competencias() {
     const nuevaFecha = prompt('Nueva fecha', comp.fecha.slice(0, 10));
     if (!nuevaFecha) return;
     try {
-      await api.put(`/competitions/${comp._id}`, {
+      await api.put(`/competencias/${comp._id}`, {
         nombre: nuevoNombre,
         fecha: nuevaFecha
       });
-      const res = await api.get(`/tournaments/${id}/competitions`);
+      const res = await api.get(`/torneos/${id}/competencias`);
       setCompetencias(Array.isArray(res.data) ? res.data : []);
     } catch (err) {
       console.error(err);
@@ -75,7 +75,7 @@ export default function Competencias() {
   const eliminarCompetencia = async (compId) => {
     if (!confirm('¿Eliminar competencia?')) return;
     try {
-      await api.delete(`/competitions/${compId}`);
+      await api.delete(`/competencias/${compId}`);
       setCompetencias(competencias.filter((c) => c._id !== compId));
     } catch (err) {
       console.error(err);

--- a/frontend-auth/src/pages/ListaBuenaFe.jsx
+++ b/frontend-auth/src/pages/ListaBuenaFe.jsx
@@ -11,7 +11,7 @@ export default function ListaBuenaFe() {
   useEffect(() => {
     const cargar = async () => {
       try {
-        const res = await api.get(`/competitions/${id}/lista-buena-fe`);
+        const res = await api.get(`/competencias/${id}/lista-buena-fe`);
         setLista(res.data);
       } catch (err) {
         console.error(err);
@@ -25,7 +25,7 @@ export default function ListaBuenaFe() {
 
   const exportar = async () => {
     try {
-      const res = await api.get(`/competitions/${id}/lista-buena-fe/excel`, {
+      const res = await api.get(`/competencias/${id}/lista-buena-fe/excel`, {
         responseType: 'blob'
       });
       const url = window.URL.createObjectURL(new Blob([res.data]));

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -34,8 +34,8 @@ export default function Notificaciones() {
   const responder = async (competenciaId, notifId, participa) => {
     const payload = { participa, notificationId: notifId };
     const endpoints = [
-      `/competitions/${competenciaId}/responder`,
-      `/competencias/${competenciaId}/responder`
+      `/competencias/${competenciaId}/responder`,
+      `/competitions/${competenciaId}/responder`
     ];
 
     let lastError = null;

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -85,7 +85,7 @@ export default function ResultadosCompetencia() {
     const cargar = async () => {
       try {
         const [resRes, resPat, resExt, resClubs] = await Promise.all([
-          api.get(`/competitions/${id}/resultados`),
+          api.get(`/competencias/${id}/resultados`),
           api.get('/patinadores'),
           api.get('/patinadores-externos'),
           api.get('/clubs')
@@ -138,9 +138,9 @@ export default function ResultadosCompetencia() {
         }
         payload.invitado = invitado;
       }
-      await api.post(`/competitions/${id}/resultados/manual`, payload);
+      await api.post(`/competencias/${id}/resultados/manual`, payload);
       const [resRes, resExt, resClubs] = await Promise.all([
-        api.get(`/competitions/${id}/resultados`),
+        api.get(`/competencias/${id}/resultados`),
         api.get('/patinadores-externos'),
         api.get('/clubs')
       ]);
@@ -163,10 +163,10 @@ export default function ResultadosCompetencia() {
     try {
       const formData = new FormData();
       formData.append('archivo', archivo);
-      await api.post(`/competitions/${id}/resultados/import-pdf`, formData, {
+      await api.post(`/competencias/${id}/resultados/import-pdf`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' }
       });
-      const res = await api.get(`/competitions/${id}/resultados`);
+      const res = await api.get(`/competencias/${id}/resultados`);
       setResultados(res.data);
       setArchivo(null);
     } catch (err) {


### PR DESCRIPTION
## Summary
- agregar rutas alias en el backend para manejar `/competencias` y `/torneos/.../competencias`
- actualizar el frontend para consumir los nuevos endpoints en español y priorizar `/competencias`
- mantener compatibilidad en notificaciones intentando ambos prefijos al responder

## Testing
- npm --prefix frontend-auth run lint
- npm --prefix backend-auth test

------
https://chatgpt.com/codex/tasks/task_e_68d097ca86548320afe6bafe960adf24