### PR TITLE
Handle auth endpoints without API prefix

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -105,6 +105,24 @@ const FRONTEND_URL = (process.env.FRONTEND_URL || FALLBACK_FRONTEND_URL).replace
 const FRONTEND_URL_WWW = (process.env.FRONTEND_URL_WWW || FALLBACK_FRONTEND_URL_WWW).replace(/\/+$/, '');
 const BACKEND_URL = (process.env.BACKEND_URL || FALLBACK_BACKEND_URL).replace(/\/+$/, '');
 
+// Some deployments proxy the backend under the `/api` prefix while others
+// forward requests directly to the Express app without rewriting the path.
+// Accepting both versions keeps the API resilient to minor proxy
+// misconfigurations and prevents confusing 404 errors such as the one
+// reported when hitting `/api/auth/login`.
+const withApiAliases = (path) => {
+  if (Array.isArray(path)) {
+    return path.flatMap(withApiAliases);
+  }
+
+  if (typeof path !== 'string' || !path.startsWith('/api/')) {
+    return [path];
+  }
+
+  const withoutApiPrefix = path.slice(4) || '/';
+  return [path, withoutApiPrefix];
+};
+
 const allowedOrigins = Array.from(
   new Set([
     ...DEFAULT_ALLOWED_ORIGINS.map((url) => url.replace(/\/+$/, '')),
@@ -289,7 +307,7 @@ async function crearNotificacionesParaTodos(mensaje, competencia = null) {
   }
 }
 
-app.post('/api/auth/registro', async (req, res) => {
+app.post(withApiAliases('/api/auth/registro'), async (req, res) => {
   const { nombre, apellido, email, password, confirmarPassword, rol, codigo } = req.body;
 
   if (!nombre || !apellido || !email || !password || !confirmarPassword || !rol) {
@@ -350,7 +368,7 @@ app.post('/api/auth/registro', async (req, res) => {
     .json({ mensaje: 'Usuario registrado con éxito. Revisa tu email para confirmar la cuenta.' });
 });
 
-app.get('/api/auth/confirmar/:token', async (req, res) => {
+app.get(withApiAliases('/api/auth/confirmar/:token'), async (req, res) => {
   const { token } = req.params;
   const usuario = await User.findOne({ tokenConfirmacion: token });
   if (!usuario) {
@@ -362,7 +380,7 @@ app.get('/api/auth/confirmar/:token', async (req, res) => {
   return res.redirect(`${FRONTEND_URL}/`);
 });
 
-app.post('/api/auth/login', async (req, res) => {
+app.post(withApiAliases('/api/auth/login'), async (req, res) => {
   try {
     const { email, password } = req.body;
     const usuario = await User.findOne({ email });
@@ -1712,7 +1730,7 @@ app.get('/api/progreso/:id', protegerRuta, async (req, res) => {
 });
 
 // Inicio de sesión con Google (OAuth 2.0 sin dependencias externas)
-app.get('/api/auth/google', (req, res) => {
+app.get(withApiAliases('/api/auth/google'), (req, res) => {
   const redirectUri =
     process.env.GOOGLE_REDIRECT_URI ||
     'https://patincarrera.net/api/auth/google/callback';
@@ -1729,7 +1747,7 @@ app.get('/api/auth/google', (req, res) => {
 });
 
 // Callback de Google
-app.get('/api/auth/google/callback', async (req, res) => {
+app.get(withApiAliases('/api/auth/google/callback'), async (req, res) => {
   const code = req.query.code;
   if (!code) {
     return res.status(400).json({ mensaje: 'Código no proporcionado por Google' });


### PR DESCRIPTION
## Summary
- add a helper that registers auth routes with and without the /api prefix so requests survive proxy rewrites
- apply the alias helper to registration, login, confirmation and Google OAuth endpoints to avoid 404s when the proxy strips /api

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d135dd2560832086e26ab851fc06ce