### PR TITLE
Improve MongoDB configuration and uploads directory handling

### DIFF
--- a/backend-auth/utils/multer.js
+++ b/backend-auth/utils/multer.js
@@ -1,9 +1,18 @@
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Ensure the uploads directory exists so Multer can save files without errors.
-const uploadDir = path.resolve('uploads');
+const uploadDir = (() => {
+  const configured = process.env.UPLOADS_DIR?.trim();
+  if (configured) {
+    return path.resolve(configured);
+  }
+  return path.resolve(__dirname, '..', 'uploads');
+})();
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }


### PR DESCRIPTION
## Summary
- resolve the uploads directory relative to the backend root or an explicit UPLOADS_DIR and propagate it so Multer and the static server share the same location
- expand MongoDB URI detection to honour several common environment variable names and log the sanitized target, preventing connection failures when variables are misnamed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d13e77e62c8320b06d7941d08d4135