### PR TITLE
Define backend URL environment fallback

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -144,7 +144,8 @@ const FALLBACK_BACKEND_URL = isProduction
 
 const FRONTEND_URL = (process.env.FRONTEND_URL || FALLBACK_FRONTEND_URL).replace(/\/+$/, '');
 const FRONTEND_URL_WWW = (process.env.FRONTEND_URL_WWW || FALLBACK_FRONTEND_URL_WWW).replace(/\/+$/, '');
-// const BACKEND_URL = (process.env.BACKEND_URL || FALLBACK_BACKEND_URL).replace(/\/+$/, '');
+const BACKEND_URL = (process.env.BACKEND_URL || FALLBACK_BACKEND_URL).replace(/\/+$/, '');
+process.env.BACKEND_URL = BACKEND_URL;
 
 // Some deployments proxy the backend under the `/api` prefix while others
 // forward requests directly to the Express app without rewriting the path.


### PR DESCRIPTION
## Summary
- restore the BACKEND_URL constant so routes that build absolute URLs do not throw
- write the resolved backend URL back to process.env for downstream modules that rely on it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14d47577083208fd2703d3d656202