### PR TITLE
Use partial unique index for external skaters

### DIFF
--- a/backend-auth/models/PatinadorExterno.js
+++ b/backend-auth/models/PatinadorExterno.js
@@ -14,7 +14,15 @@ const patinadorExternoSchema = new mongoose.Schema(
 
 patinadorExternoSchema.index(
   { primerNombre: 1, segundoNombre: 1, apellido: 1, club: 1 },
-  { unique: true }
+  {
+    unique: true,
+    partialFilterExpression: {
+      primerNombre: { $type: 'string' },
+      segundoNombre: { $type: 'string' },
+      apellido: { $type: 'string' },
+      club: { $type: 'string' }
+    }
+  }
 );
 
 patinadorExternoSchema.pre('save', function (next) {


### PR DESCRIPTION
## Summary
- update the PatinadorExterno schema to build the unique compound index only for documents that contain string values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d150de47c0832098ef6b0e7f7d6918