### PR TITLE
Handle missing login payload

### DIFF
--- a/backend-auth/controllers/authController.js
+++ b/backend-auth/controllers/authController.js
@@ -60,7 +60,13 @@ export const confirmarCuenta = async (req, res) => {
 // Login de usuario
 export const loginUsuario = async (req, res) => {
   try {
-    const { email, password } = req.body;
+    const body = req.body ?? {};
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+
+    if (!email || !password) {
+      return res.status(400).json({ mensaje: 'Email y contraseña son obligatorios' });
+    }
 
     const usuario = await User.findOne({ email });
 

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -473,7 +473,14 @@ app.get(withApiAliases('/api/auth/confirmar/:token'), async (req, res) => {
 
 app.post(withApiAliases('/api/auth/login'), async (req, res) => {
   try {
-    const { email, password } = req.body;
+    const body = req.body ?? {};
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+
+    if (!email || !password) {
+      return res.status(400).json({ mensaje: 'Email y contraseña son obligatorios' });
+    }
+
     const usuario = await User.findOne({ email });
     if (!usuario) {
       return res.status(400).json({ mensaje: 'Credenciales inválidas' });


### PR DESCRIPTION
## Summary
- add guards to the controller-based login flow so missing bodies return a 400 instead of crashing
- mirror the same validation in the inline Express route that handles `/api/auth/login`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d20efe5d84832098e3d9fe2e7c4018