### PR TITLE
Update login page title text

### DIFF
--- a/frontend-auth/src/pages/Auth.jsx
+++ b/frontend-auth/src/pages/Auth.jsx
@@ -10,7 +10,7 @@ export default function Auth() {
       <div className="row justify-content-center">
         <div className="col-12 col-md-6">
           <h1 className="text-center mb-4">
-            {mostrarRegistro ? 'Registrarse' : 'Iniciar sesión'}
+            {mostrarRegistro ? 'Registrarse' : 'Empieza ahora'}
           </h1>
           <div className="card p-4">
             {mostrarRegistro ? <RegisterForm /> : <LoginForm />}


### PR DESCRIPTION
## Summary
- update the login view heading to display "Empieza ahora" when the sign-in form is shown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d28400911c83209aeb1090fe078fd9