### PR TITLE
Prepare deployment configuration for patincarrera.net

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -50,10 +50,16 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    ```bash
    sudo cp deployment/nginx.conf /etc/nginx/sites-available/patincarrera
    sudo ln -s /etc/nginx/sites-available/patincarrera /etc/nginx/sites-enabled/
+   # If you placed the frontend bundle in a different directory, edit the
+   # server block and update the `root` directive accordingly before
+   # restarting Nginx.
+   sudo nano /etc/nginx/sites-available/patincarrera
    sudo nginx -t
    sudo systemctl restart nginx
    ```
 2. Point the domain DNS records for `patincarrera.net` and `www.patincarrera.net` to the server IP `72.60.62.242`.
+3. Once HTTPS certificates are issued you can uncomment the redirect in the
+   provided config so every visitor is forced to use `https://`.
 
 ## 5. Optional HTTPS
 Use [Certbot](https://certbot.eff.org/) to obtain a Let's Encrypt certificate:

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name patincarrera.net www.patincarrera.net;
+
+    # Serve the Vite build generated with `npm run build`
+    root /var/www/patincarrera/frontend/dist;
+    index index.html;
+
+    # Allow large JSON bodies and uploads that the API already expects.
+    client_max_body_size 100M;
+
+    # Optional: redirect all HTTP traffic to HTTPS once certificates are installed.
+    # return 301 https://$host$request_uri;
+
+    access_log /var/log/nginx/patincarrera.access.log;
+    error_log /var/log/nginx/patincarrera.error.log;
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:5000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+    }
+
+    # Expose profile pictures and other uploaded assets handled by Express.
+    location /uploads/ {
+        proxy_pass http://127.0.0.1:5000/uploads/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend-auth/index.html
+++ b/frontend-auth/index.html
@@ -1,9 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Sitio oficial de Patín Carrera General Rodríguez. Accede a noticias, inscripciones y seguimiento de patinadores en patincarrera.net."
+    />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
@@ -13,7 +17,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
     />
-    <title>Vite + React</title>
+    <title>Patín Carrera General Rodríguez</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add an nginx server block for patincarrera.net that serves the Vite build and proxies API/uploads to Node.js
- expand the deployment guide with notes on adjusting the document root and enabling the HTTPS redirect once certificates exist
- brand the Vite entry document for patincarrera.net with the proper language, description and title

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ad5b40748320bc099c50be278bfa