### PR TITLE
Add protected endpoint to list users for admin panel

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -494,6 +494,23 @@ app.get('/api/protegido/usuario', protegerRuta, async (req, res) => {
   }
 });
 
+app.get(
+  '/api/protegido/usuarios',
+  protegerRuta,
+  permitirRol('Delegado', 'Admin', 'admin'),
+  async (req, res) => {
+    try {
+      const usuarios = await User.find()
+        .select('-password')
+        .sort({ apellido: 1, nombre: 1 });
+      res.json(usuarios);
+    } catch (err) {
+      console.error('Error al obtener usuarios', err);
+      res.status(500).json({ mensaje: 'Error al obtener usuarios' });
+    }
+  }
+);
+
 app.post(
   '/api/protegido/foto-perfil',
   protegerRuta,


### PR DESCRIPTION
## Summary
- expose a GET /api/protegido/usuarios endpoint guarded by the existing auth middleware so the admin panel can load users

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3fb8453488320a2ad0caeeb8c573f