### PR TITLE
Fix dev API base URL fallback

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -15,7 +15,11 @@ const buildApiBaseUrl = () => {
   const { protocol, hostname, origin } = window.location;
   const isLocalHost = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/i.test(hostname);
 
-  if (isLocalHost) {
+  // During local development the Vite dev server might be accessed via the
+  // machine's LAN IP (e.g. from a phone on the same network). In those cases
+  // `hostname` isn't `localhost` so we also check `import.meta.env.DEV` to keep
+  // pointing requests to the Express server running on the backend port.
+  if (isLocalHost || import.meta.env.DEV) {
     const port = backendPort || '5000';
     return `${protocol}//${hostname}:${port}/api`;
   }


### PR DESCRIPTION
## Summary
- ensure the frontend API client falls back to the backend port even when the dev server is opened from a LAN IP
- document the intent behind the new fallback so development from other devices keeps working

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4025445b0832097043f9c039cf0d3