### PR TITLE
Fix missing media by normalizing image URLs

### DIFF
--- a/frontend-auth/src/components/LoginForm.jsx
+++ b/frontend-auth/src/components/LoginForm.jsx
@@ -1,5 +1,6 @@
 import api from '../api';
 import { useNavigate } from 'react-router-dom';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function LoginForm() {
   const navigate = useNavigate();
@@ -9,15 +10,21 @@ export default function LoginForm() {
     const email = e.target.email.value;
     const password = e.target.password.value;
 
-      try {
-        const res = await api.post('/auth/login', { email, password });
+    try {
+      const res = await api.post('/auth/login', { email, password });
 
       const { token, usuario } = res.data;
 
       // Guardamos el token y rol en localStorage
       localStorage.setItem('token', token);
       localStorage.setItem('rol', usuario.rol);
-      localStorage.setItem('foto', usuario.foto || '');
+
+      const foto = getImageUrl(usuario.foto);
+      if (foto) {
+        localStorage.setItem('foto', foto);
+      } else {
+        localStorage.removeItem('foto');
+      }
 
       alert(`Bienvenido ${usuario.nombre}`);
       // Redirigir a la página de noticias

--- a/frontend-auth/src/components/LogoutButton.jsx
+++ b/frontend-auth/src/components/LogoutButton.jsx
@@ -6,6 +6,7 @@ export default function LogoutButton() {
   const handleLogout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('rol');
+    localStorage.removeItem('foto');
     navigate('/');
   };
 

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -2,12 +2,22 @@ import { useRef, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../api';
 import LogoutButton from './LogoutButton';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function Navbar() {
   const navigate = useNavigate();
   const fileInputRef = useRef(null);
   const rol = localStorage.getItem('rol');
-  const foto = localStorage.getItem('foto');
+  const storedFoto = localStorage.getItem('foto');
+  const normalisedFoto = getImageUrl(storedFoto);
+  if (storedFoto && normalisedFoto !== storedFoto) {
+    if (normalisedFoto) {
+      localStorage.setItem('foto', normalisedFoto);
+    } else {
+      localStorage.removeItem('foto');
+    }
+  }
+  const foto = normalisedFoto;
   const isLoggedIn = localStorage.getItem('token');
   const [unread, setUnread] = useState(0);
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
@@ -99,7 +109,12 @@ export default function Navbar() {
             }
           }
         );
-      localStorage.setItem('foto', res.data.foto);
+      const nuevaFoto = getImageUrl(res.data.foto);
+      if (nuevaFoto) {
+        localStorage.setItem('foto', nuevaFoto);
+      } else {
+        localStorage.removeItem('foto');
+      }
       window.location.reload();
     } catch (err) {
       console.error(err);

--- a/frontend-auth/src/pages/AsociarPatinadores.jsx
+++ b/frontend-auth/src/pages/AsociarPatinadores.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function AsociarPatinadores() {
   const [dniPadre, setDniPadre] = useState('');
@@ -11,7 +12,14 @@ export default function AsociarPatinadores() {
     e.preventDefault();
     try {
       const res = await api.post('/patinadores/asociar', { dniPadre, dniMadre });
-      setPatinadores(res.data);
+      const datos = Array.isArray(res.data)
+        ? res.data.map((p) => ({
+            ...p,
+            foto: getImageUrl(p.foto),
+            fotoRostro: getImageUrl(p.fotoRostro)
+          }))
+        : [];
+      setPatinadores(datos);
       setError('');
     } catch (err) {
       setPatinadores([]);

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function Competencias() {
   const { id } = useParams();
@@ -16,7 +17,13 @@ export default function Competencias() {
     const cargar = async () => {
       try {
         const res = await api.get(`/tournaments/${id}/competitions`);
-        setCompetencias(res.data);
+        const datos = Array.isArray(res.data)
+          ? res.data.map((comp) => ({
+              ...comp,
+              imagen: getImageUrl(comp.imagen)
+            }))
+          : [];
+        setCompetencias(datos);
       } catch (err) {
         console.error(err);
         setError('Error al cargar competencias');
@@ -45,7 +52,13 @@ export default function Competencias() {
       setFecha('');
       e.target.imagen.value = '';
       const res = await api.get(`/tournaments/${id}/competitions`);
-      setCompetencias(res.data);
+      const datos = Array.isArray(res.data)
+        ? res.data.map((comp) => ({
+            ...comp,
+            imagen: getImageUrl(comp.imagen)
+          }))
+        : [];
+      setCompetencias(datos);
     } catch (err) {
       console.error(err);
       alert('Error al crear competencia');
@@ -63,7 +76,13 @@ export default function Competencias() {
         fecha: nuevaFecha
       });
       const res = await api.get(`/tournaments/${id}/competitions`);
-      setCompetencias(res.data);
+      const datos = Array.isArray(res.data)
+        ? res.data.map((item) => ({
+            ...item,
+            imagen: getImageUrl(item.imagen)
+          }))
+        : [];
+      setCompetencias(datos);
     } catch (err) {
       console.error(err);
       alert('Error al actualizar competencia');

--- a/frontend-auth/src/pages/Dashboard.jsx
+++ b/frontend-auth/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import LogoutButton from '../components/LogoutButton';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function Dashboard() {
   const [rol, setRol] = useState('');
@@ -9,13 +10,28 @@ export default function Dashboard() {
 
   useEffect(() => {
     setRol(localStorage.getItem('rol'));
-    setFoto(localStorage.getItem('foto'));
+    const storedFoto = getImageUrl(localStorage.getItem('foto'));
+    if (storedFoto) {
+      localStorage.setItem('foto', storedFoto);
+      setFoto(storedFoto);
+    } else {
+      localStorage.removeItem('foto');
+      setFoto('');
+    }
 
     // Podés cargar más info si querés desde el backend
     const cargarDatos = async () => {
       try {
         const res = await api.get('/protegido/usuario');
-        setUsuario(res.data.usuario);
+        const usuarioData = {
+          ...res.data.usuario,
+          foto: getImageUrl(res.data.usuario?.foto)
+        };
+        setUsuario(usuarioData);
+        if (usuarioData.foto) {
+          localStorage.setItem('foto', usuarioData.foto);
+          setFoto(usuarioData.foto);
+        }
       } catch (err) {
         console.log(err);
       }
@@ -40,8 +56,11 @@ export default function Dashboard() {
       });
 
       alert('Foto actualizada');
-      localStorage.setItem('foto', res.data.foto);
-      setFoto(res.data.foto);
+      const nuevaFoto = getImageUrl(res.data.foto);
+      if (nuevaFoto) {
+        localStorage.setItem('foto', nuevaFoto);
+        setFoto(nuevaFoto);
+      }
       setNuevaFoto(null);
     } catch (err) {
       console.error(err);

--- a/frontend-auth/src/pages/GoogleSuccess.jsx
+++ b/frontend-auth/src/pages/GoogleSuccess.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
+import getImageUrl from '../utils/getImageUrl';
 
 
 export default function GoogleSuccess() {
@@ -14,8 +15,11 @@ export default function GoogleSuccess() {
       const datos = jwtDecode(token);
       localStorage.setItem('token', token);
       localStorage.setItem('rol', datos.rol);
-      if (datos.foto) {
-        localStorage.setItem('foto', datos.foto);
+      const foto = getImageUrl(datos.foto);
+      if (foto) {
+        localStorage.setItem('foto', foto);
+      } else {
+        localStorage.removeItem('foto');
       }
   
       navigate('/home');

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function Home() {
   const [news, setNews] = useState([]);
@@ -13,7 +14,13 @@ export default function Home() {
     const cargarNoticias = async () => {
       try {
         const newsRes = await api.get('/news');
-        setNews(newsRes.data);
+        const normalized = Array.isArray(newsRes.data)
+          ? newsRes.data.map((item) => ({
+              ...item,
+              imagen: getImageUrl(item.imagen)
+            }))
+          : [];
+        setNews(normalized);
       } catch (err) {
         console.error(err);
       }
@@ -22,7 +29,14 @@ export default function Home() {
     const cargarPatinadores = async () => {
       try {
         const userRes = await api.get('/protegido/usuario');
-        setPatinadores(userRes.data.usuario.patinadores || []);
+        const patinadoresData = Array.isArray(userRes.data.usuario?.patinadores)
+          ? userRes.data.usuario.patinadores.map((p) => ({
+              ...p,
+              foto: getImageUrl(p.foto),
+              fotoRostro: getImageUrl(p.fotoRostro)
+            }))
+          : [];
+        setPatinadores(patinadoresData);
       } catch (err) {
         console.error(err);
       }
@@ -31,7 +45,12 @@ export default function Home() {
     const cargarCompetencia = async () => {
       try {
         const compRes = await api.get('/competencias');
-        const comps = compRes.data;
+        const comps = Array.isArray(compRes.data)
+          ? compRes.data.map((comp) => ({
+              ...comp,
+              imagen: getImageUrl(comp.imagen)
+            }))
+          : [];
         if (comps.length > 0) {
           const sorted = comps.sort(
             (a, b) => new Date(a.fecha) - new Date(b.fecha)

--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function ListaPatinadores() {
   const [patinadores, setPatinadores] = useState([]);
@@ -11,7 +12,14 @@ export default function ListaPatinadores() {
     const obtenerPatinadores = async () => {
       try {
         const res = await api.get('/patinadores');
-        setPatinadores(res.data);
+        const patinadoresData = Array.isArray(res.data)
+          ? res.data.map((p) => ({
+              ...p,
+              foto: getImageUrl(p.foto),
+              fotoRostro: getImageUrl(p.fotoRostro)
+            }))
+          : [];
+        setPatinadores(patinadoresData);
       } catch (err) {
         console.error(err);
       }
@@ -23,7 +31,7 @@ export default function ListaPatinadores() {
     if (!window.confirm('¿Eliminar patinador?')) return;
     try {
       await api.delete(`/patinadores/${id}`);
-      setPatinadores(patinadores.filter((p) => p._id !== id));
+      setPatinadores((prev) => prev.filter((p) => p._id !== id));
     } catch (err) {
       console.error(err);
     }

--- a/frontend-auth/src/pages/VerNoticia.jsx
+++ b/frontend-auth/src/pages/VerNoticia.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function VerNoticia() {
   const { id } = useParams();
@@ -10,7 +11,10 @@ export default function VerNoticia() {
     const fetchNoticia = async () => {
       try {
         const res = await api.get(`/news/${id}`);
-        setNoticia(res.data);
+        setNoticia({
+          ...res.data,
+          imagen: getImageUrl(res.data?.imagen)
+        });
       } catch (err) {
         console.error(err);
       }

--- a/frontend-auth/src/pages/VerPatinador.jsx
+++ b/frontend-auth/src/pages/VerPatinador.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import api from '../api';
+import getImageUrl from '../utils/getImageUrl';
 
 export default function VerPatinador() {
   const { id } = useParams();
@@ -10,7 +11,11 @@ export default function VerPatinador() {
     const fetchPatinador = async () => {
       try {
         const res = await api.get(`/patinadores/${id}`);
-        setPatinador(res.data);
+        setPatinador({
+          ...res.data,
+          foto: getImageUrl(res.data?.foto),
+          fotoRostro: getImageUrl(res.data?.fotoRostro)
+        });
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
## Summary
- improve image URL normalization to handle same-domain uploads and legacy paths
- normalize news, patinador, competition, and profile data before rendering
- sanitize profile photo storage across login, Google auth, navbar, and logout flows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ccf18678832086ec284ed75add57