### PR TITLE
Fix default avatar fallback for profile images

### DIFF
--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import api from '../api';
 import LogoutButton from './LogoutButton';
 import getImageUrl from '../utils/getImageUrl';
+import placeholderAvatar from '../assets/image-placeholder.svg';
 
 export default function Navbar() {
   const navigate = useNavigate();
@@ -18,6 +19,8 @@ export default function Navbar() {
     }
   }
   const foto = normalisedFoto;
+  const displayPhoto = foto || placeholderAvatar;
+  const isGooglePhoto = Boolean(foto?.includes('googleusercontent'));
   const isLoggedIn = localStorage.getItem('token');
   const [unread, setUnread] = useState(0);
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
@@ -262,16 +265,16 @@ export default function Navbar() {
                 </div>
                 <div className="position-relative">
                   <img
-                    src={foto || '/default-user.png'}
+                    src={displayPhoto}
                     alt="Foto perfil"
                     width="40"
                     height="40"
                     className="rounded-circle"
-                    style={{ objectFit: 'cover', cursor: foto?.includes('googleusercontent') ? 'default' : 'pointer' }}
+                    style={{ objectFit: 'cover', cursor: isGooglePhoto ? 'default' : 'pointer' }}
                     referrerPolicy="no-referrer"
-                    onClick={!foto?.includes('googleusercontent') ? triggerFileSelect : undefined}
+                    onClick={!isGooglePhoto ? triggerFileSelect : undefined}
                   />
-                  {!foto?.includes('googleusercontent') && (
+                  {!isGooglePhoto && (
                     <input
                       type="file"
                       accept="image/*"

--- a/frontend-auth/src/pages/Dashboard.jsx
+++ b/frontend-auth/src/pages/Dashboard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import LogoutButton from '../components/LogoutButton';
 import api from '../api';
 import getImageUrl from '../utils/getImageUrl';
+import defaultAvatar from '../assets/image-placeholder.svg';
 
 export default function Dashboard() {
   const [rol, setRol] = useState('');
@@ -77,7 +78,7 @@ export default function Dashboard() {
 
       <div className="card p-3 mb-4 d-flex flex-row align-items-center gap-3">
         <img
-          src={foto || '/default-user.png'}
+          src={foto || defaultAvatar}
           alt="Perfil"
           className="rounded-circle"
           width="80"


### PR DESCRIPTION
## Summary
- load the bundled placeholder avatar when a user has no stored profile photo
- keep Google account detection for profile images while preventing broken image requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6050dd0dc8320b2ba07739d00b19b