### PR TITLE
Center headings across frontend and rename home title

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -72,7 +72,7 @@ export default function Footer() {
             </div>
           </div>
           <div className="col-md-3">
-            <h5>Contacto</h5>
+            <h5 className="text-center">Contacto</h5>
             <form onSubmit={handleSubmit}>
               <div className="mb-2">
                 <textarea
@@ -114,7 +114,7 @@ export default function Footer() {
             </ul>
           </div>
           <div className="col-md-4 mb-4 text-center">
-            <h5>Enlaces</h5>
+            <h5 className="text-center">Enlaces</h5>
             <ul className="list-unstyled">
               <li>
                 <Link to="/home" className="text-light text-decoration-none">

--- a/frontend-auth/src/pages/AsociarPatinadores.jsx
+++ b/frontend-auth/src/pages/AsociarPatinadores.jsx
@@ -29,7 +29,7 @@ export default function AsociarPatinadores() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-3">Asociar Patinadores</h1>
+      <h1 className="mb-3 text-center">Asociar Patinadores</h1>
       <form onSubmit={handleSubmit} className="mb-4">
         <div className="mb-3">
           <label className="form-label">DNI del Padre</label>
@@ -58,7 +58,7 @@ export default function AsociarPatinadores() {
             <img src={p.foto} className="card-img-top" alt="foto patinador" />
           )}
           <div className="card-body">
-            <h5 className="card-title">{p.primerNombre} {p.apellido}</h5>
+            <h5 className="card-title text-center">{p.primerNombre} {p.apellido}</h5>
             <p className="card-text"><strong>Categoría:</strong> {p.categoria}</p>
             <p className="card-text"><strong>Edad:</strong> {p.edad}</p>
           </div>

--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -47,7 +47,7 @@ export default function CargarPatinador() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Cargar Patinador</h1>
+      <h1 className="mb-4 text-center">Cargar Patinador</h1>
       <form onSubmit={handleSubmit}>
         <div className="row g-3">
           <div className="col-md-6">

--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -105,7 +105,7 @@ export default function Competencias() {
 
   return (
     <div className="container mt-3">
-      <h2>Competencias</h2>
+      <h2 className="text-center">Competencias</h2>
       {rol === 'Delegado' && (
         <form onSubmit={crearCompetencia} className="row g-2 mb-3" encType="multipart/form-data">
           <div className="col-md-4">

--- a/frontend-auth/src/pages/CrearNoticia.jsx
+++ b/frontend-auth/src/pages/CrearNoticia.jsx
@@ -22,7 +22,7 @@ export default function CrearNoticia() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Crear Noticia</h1>
+      <h1 className="mb-4 text-center">Crear Noticia</h1>
       <form onSubmit={handleSubmit}>
         <div className="mb-3">
           <label className="form-label">Título</label>

--- a/frontend-auth/src/pages/CrearNotificacion.jsx
+++ b/frontend-auth/src/pages/CrearNotificacion.jsx
@@ -16,7 +16,7 @@ export default function CrearNotificacion() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Crear Notificación</h1>
+      <h1 className="mb-4 text-center">Crear Notificación</h1>
       <form onSubmit={handleSubmit}>
         <div className="mb-3">
           <label className="form-label">Mensaje</label>

--- a/frontend-auth/src/pages/Dashboard.jsx
+++ b/frontend-auth/src/pages/Dashboard.jsx
@@ -71,9 +71,11 @@ export default function Dashboard() {
 
   return (
     <div className="container mt-4">
-      <div className="d-flex justify-content-between align-items-center mb-4">
-        <h1 className="m-0">Bienvenido al Dashboard</h1>
-        <LogoutButton />
+      <div className="d-flex flex-column flex-md-row align-items-center mb-4">
+        <h1 className="m-0 text-center flex-grow-1 w-100">Bienvenido al Dashboard</h1>
+        <div className="mt-3 mt-md-0 ms-md-3">
+          <LogoutButton />
+        </div>
       </div>
 
       <div className="card p-3 mb-4 d-flex flex-row align-items-center gap-3">

--- a/frontend-auth/src/pages/EditarPatinador.jsx
+++ b/frontend-auth/src/pages/EditarPatinador.jsx
@@ -65,7 +65,7 @@ export default function EditarPatinador() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Editar Patinador</h1>
+      <h1 className="mb-4 text-center">Editar Patinador</h1>
       <form onSubmit={handleSubmit}>
         <div className="row g-3">
           <div className="col-md-6">

--- a/frontend-auth/src/pages/Entrenamientos.jsx
+++ b/frontend-auth/src/pages/Entrenamientos.jsx
@@ -124,7 +124,7 @@ export default function Entrenamientos() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Entrenamientos</h1>
+      <h1 className="mb-4 text-center">Entrenamientos</h1>
       {asistencias.length === 0 ? (
         <>
           <button className="btn btn-primary mb-3" onClick={iniciarNuevo}>

--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -113,7 +113,7 @@ export default function Home() {
       )}
       <div className="container mt-4">
 
-        <h1 className="mb-4">Noticias Falsas</h1>
+        <h1 className="mb-4 text-center">Noticias</h1>
 
         <div className="news-grid">
           {displayedNews[0] && (
@@ -125,7 +125,7 @@ export default function Home() {
               <div className="top-news-text">
                 <div className="news-label-top">NOTICIA</div>
                 <div className="news-label-top-line" />
-                <h5>{displayedNews[0].titulo}</h5>
+                <h5 className="text-center">{displayedNews[0].titulo}</h5>
                 <p>{displayedNews[0].contenido?.slice(0, 100)}...</p>
               </div>
               {displayedNews[0].imagen && (
@@ -142,7 +142,7 @@ export default function Home() {
                   <img src={currentPatinador.foto} alt="foto patinador" />
                 )}
                 <div className="overlay">
-                  <h6>
+                  <h6 className="text-center">
                     {currentPatinador.primerNombre} {currentPatinador.apellido}
                   </h6>
                 </div>
@@ -167,7 +167,7 @@ export default function Home() {
                 </div>
               )}
               <div className="news-info">
-                <h6>{displayedNews[1].titulo}</h6>
+                <h6 className="text-center">{displayedNews[1].titulo}</h6>
                 <p>{displayedNews[1].contenido?.slice(0, 80)}...</p>
                 <div className="news-divider" />
                 <div className="news-footer">
@@ -195,7 +195,7 @@ export default function Home() {
                 </div>
               )}
               <div className="news-info">
-                <h6>{displayedNews[2].titulo}</h6>
+                <h6 className="text-center">{displayedNews[2].titulo}</h6>
                 <p>{displayedNews[2].contenido?.slice(0, 80)}...</p>
                 <div className="news-divider" />
                 <div className="news-footer">
@@ -223,7 +223,7 @@ export default function Home() {
                 </div>
               )}
               <div className="news-info">
-                <h6>{displayedNews[3].titulo}</h6>
+                <h6 className="text-center">{displayedNews[3].titulo}</h6>
                 <p>{displayedNews[3].contenido?.slice(0, 80)}...</p>
                 <div className="news-divider" />
                 <div className="news-footer">
@@ -247,7 +247,7 @@ export default function Home() {
                 <div className="news-label-line" />
               </div>
               <div className="news-info">
-                <h6>{nextCompetition.nombre}</h6>
+                <h6 className="text-center">{nextCompetition.nombre}</h6>
                 <p>{new Date(nextCompetition.fecha).toLocaleDateString()}</p>
                 <div className="news-divider" />
                 <div className="news-footer">
@@ -283,7 +283,7 @@ export default function Home() {
                   />
                   <span>Patín carrera General Rodríguez</span>
                 </div>
-                <h6>
+                <h6 className="text-center">
                   {item.titulo.length > 60
                     ? `${item.titulo.slice(0, 60)}...`
                     : item.titulo}
@@ -310,7 +310,7 @@ export default function Home() {
                   </div>
                 )}
                 <div className="news-info">
-                  <h6>{item.titulo}</h6>
+                  <h6 className="text-center">{item.titulo}</h6>
                   <p>{item.contenido?.slice(0, 80)}...</p>
                   <div className="news-divider" />
                   <div className="news-footer">
@@ -344,7 +344,7 @@ export default function Home() {
                   </div>
                 )}
                 <div className="news-info">
-                  <h6>{item.titulo}</h6>
+                  <h6 className="text-center">{item.titulo}</h6>
                   <p>{item.contenido?.slice(0, 80)}...</p>
                   <div className="news-divider" />
                   <div className="news-footer">

--- a/frontend-auth/src/pages/ListaBuenaFe.jsx
+++ b/frontend-auth/src/pages/ListaBuenaFe.jsx
@@ -46,7 +46,7 @@ export default function ListaBuenaFe() {
 
   return (
     <div className="container mt-3">
-      <h2>Lista de Buena Fe</h2>
+      <h2 className="text-center">Lista de Buena Fe</h2>
       <button className="btn btn-success mb-3" onClick={exportar}>
         Exportar a Excel
       </button>

--- a/frontend-auth/src/pages/ListaPatinadores.jsx
+++ b/frontend-auth/src/pages/ListaPatinadores.jsx
@@ -94,7 +94,7 @@ export default function ListaPatinadores() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Patinadores</h1>
+      <h1 className="mb-4 text-center">Patinadores</h1>
       <div className="row">
         {patinadores.map((p) => (
           <div className="col-md-4 mb-4" key={p._id}>
@@ -107,7 +107,7 @@ export default function ListaPatinadores() {
                 />
               )}
               <div className="card-body d-flex flex-column">
-                <h5 className="card-title">
+                <h5 className="card-title text-center">
                   {p.primerNombre} {p.apellido}
                 </h5>
                 <p className="card-text">Edad: {p.edad}</p>

--- a/frontend-auth/src/pages/Notificaciones.jsx
+++ b/frontend-auth/src/pages/Notificaciones.jsx
@@ -63,7 +63,7 @@ export default function Notificaciones() {
   if (notificaciones.length === 0) {
     return (
       <div className="container mt-4 text-black fw-normal">
-        <h1 className="mb-4 fw-normal">Notificaciones</h1>
+        <h1 className="mb-4 fw-normal text-center">Notificaciones</h1>
         <p>No hay notificaciones.</p>
       </div>
     );
@@ -71,7 +71,7 @@ export default function Notificaciones() {
 
   return (
     <div className="container mt-4 text-black fw-normal">
-      <h1 className="mb-4 fw-normal">Notificaciones</h1>
+      <h1 className="mb-4 fw-normal text-center">Notificaciones</h1>
       <ul className="list-group">
         {notificaciones.map((n) => (
           <li key={n._id} className={`list-group-item ${n.leido ? '' : 'list-group-item-warning'}`}>

--- a/frontend-auth/src/pages/PanelAdmin.jsx
+++ b/frontend-auth/src/pages/PanelAdmin.jsx
@@ -16,11 +16,13 @@ export default function PanelAdmin() {
 
   return (
     <div className="container mt-4">
-      <div className="d-flex justify-content-between align-items-center mb-4">
-        <h1 className="m-0">Panel de Administración</h1>
-        <LogoutButton />
+      <div className="d-flex flex-column flex-md-row align-items-center mb-4">
+        <h1 className="m-0 text-center flex-grow-1 w-100">Panel de Administración</h1>
+        <div className="mt-3 mt-md-0 ms-md-3">
+          <LogoutButton />
+        </div>
       </div>
-      <h2 className="mb-3">Usuarios registrados</h2>
+      <h2 className="mb-3 text-center">Usuarios registrados</h2>
       <div className="table-responsive">
         <table className="table table-striped">
           <thead>

--- a/frontend-auth/src/pages/Progresos.jsx
+++ b/frontend-auth/src/pages/Progresos.jsx
@@ -61,7 +61,7 @@ export default function Progresos() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Progresos</h1>
+      <h1 className="mb-4 text-center">Progresos</h1>
       <div className="mb-3">
         <label className="form-label">Patinador</label>
         <select className="form-select" value={patinadorId} onChange={manejarCambioPatinador}>

--- a/frontend-auth/src/pages/RankingClubes.jsx
+++ b/frontend-auth/src/pages/RankingClubes.jsx
@@ -28,7 +28,7 @@ export default function RankingClubes() {
 
   return (
     <div className="container mt-3">
-      <h2>Ranking de Clubes</h2>
+      <h2 className="text-center">Ranking de Clubes</h2>
       {clubes.length === 0 ? (
         <p>No hay datos.</p>
       ) : (

--- a/frontend-auth/src/pages/RankingTorneo.jsx
+++ b/frontend-auth/src/pages/RankingTorneo.jsx
@@ -28,14 +28,14 @@ export default function RankingTorneo() {
 
   return (
     <div className="container mt-3">
-      <h2>Ranking</h2>
-      <h4>Individual por Categoría</h4>
+      <h2 className="text-center">Ranking</h2>
+      <h4 className="text-center">Individual por Categoría</h4>
       {individual.length === 0 ? (
         <p>No hay datos.</p>
       ) : (
         individual.map((cat) => (
           <div key={cat.categoria} className="mb-3">
-            <h5>{cat.categoria}</h5>
+            <h5 className="text-center">{cat.categoria}</h5>
             <ul className="list-group">
               {cat.patinadores.map((p, idx) => (
                 <li

--- a/frontend-auth/src/pages/Reportes.jsx
+++ b/frontend-auth/src/pages/Reportes.jsx
@@ -36,7 +36,7 @@ export default function Reportes() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Reportes</h1>
+      <h1 className="mb-4 text-center">Reportes</h1>
       <div className="mb-3">
         <label className="form-label">Patinador</label>
         <select className="form-select" value={patinadorId} onChange={manejarCambio}>

--- a/frontend-auth/src/pages/ResultadosCompetencia.jsx
+++ b/frontend-auth/src/pages/ResultadosCompetencia.jsx
@@ -180,7 +180,7 @@ export default function ResultadosCompetencia() {
 
   return (
     <div className="container mt-3">
-      <h2>Resultados</h2>
+      <h2 className="text-center">Resultados</h2>
       {rol === 'Delegado' && (
         <>
           <form onSubmit={importar} className="mb-3">

--- a/frontend-auth/src/pages/SolicitarSeguro.jsx
+++ b/frontend-auth/src/pages/SolicitarSeguro.jsx
@@ -297,9 +297,9 @@ export default function SolicitarSeguro() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">Solicitar Seguro</h1>
+      <h1 className="mb-4 text-center">Solicitar Seguro</h1>
         <div className="mb-4">
-          <h5>Deportista</h5>
+          <h5 className="text-center">Deportista</h5>
           <div className="d-flex gap-2">
             <select
               className="form-select"
@@ -328,7 +328,7 @@ export default function SolicitarSeguro() {
           </div>
         </div>
         <div className="mb-4">
-          <h5>Delegado</h5>
+          <h5 className="text-center">Delegado</h5>
           <form className="row g-2" onSubmit={agregarDelegado}>
             <div className="col-md-4">
               <input

--- a/frontend-auth/src/pages/Torneos.jsx
+++ b/frontend-auth/src/pages/Torneos.jsx
@@ -85,7 +85,7 @@ export default function Torneos() {
 
   return (
     <div className="container mt-3">
-      <h2>Torneos</h2>
+      <h2 className="text-center">Torneos</h2>
       {rol === 'Delegado' && (
         <form onSubmit={crearTorneo} className="row g-2 mb-3">
           <div className="col-md-4">

--- a/frontend-auth/src/pages/VerNoticia.jsx
+++ b/frontend-auth/src/pages/VerNoticia.jsx
@@ -29,7 +29,7 @@ export default function VerNoticia() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-3">{noticia.titulo}</h1>
+      <h1 className="mb-3 text-center">{noticia.titulo}</h1>
       {noticia.imagen && (
         <img
           src={noticia.imagen}

--- a/frontend-auth/src/pages/VerPatinador.jsx
+++ b/frontend-auth/src/pages/VerPatinador.jsx
@@ -34,7 +34,7 @@ export default function VerPatinador() {
 
   return (
     <div className="container mt-4">
-      <h1>
+      <h1 className="text-center">
         {patinador.primerNombre} {patinador.segundoNombre ? `${patinador.segundoNombre} ` : ''}
         {patinador.apellido}
       </h1>

--- a/frontend-auth/src/pages/VerReporte.jsx
+++ b/frontend-auth/src/pages/VerReporte.jsx
@@ -28,7 +28,7 @@ export default function VerReporte() {
 
   return (
     <div className="container mt-4">
-      <h1 className="mb-4">
+      <h1 className="mb-4 text-center">
         Reporte de {reporte.patinador.primerNombre} {reporte.patinador.apellido}
       </h1>
       <p>


### PR DESCRIPTION
## Summary
- rename the Home page heading to "Noticias" and center the news card titles
- apply centered alignment to all page and section headings, adjusting admin and dashboard toolbars to keep actions accessible
- center footer section headers for visual consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6079834f0832091f9b3ad58df233a