### PR TITLE
Add PM2 config and deployment helper script

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,7 +24,11 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    # NODE_ENV=production (present in the example file) ensures the backend
    # uses https://patincarrera.net as the default domain for redirects & CORS.
    npm install
-   pm2 start server.js --name patincarrera-backend
+   # PM2 is now configured via backend-auth/ecosystem.config.js so we can
+   # keep the runtime options under version control. The file assumes the
+   # project lives in /home/deploy/apps/patincarreraGR; adjust `cwd`,
+   # log paths or environment variables if your setup differs.
+   pm2 startOrReload ecosystem.config.js --update-env
    pm2 save
    cd ..
    ```
@@ -71,3 +75,13 @@ sudo certbot --nginx -d patincarrera.net -d www.patincarrera.net
 ## Notes
 - Update environment variables as needed for production.
 - PM2 will keep the backend running and revive it on reboot (`pm2 startup`).
+- For future releases you can deploy everything in one step from the project
+  root:
+
+  ```bash
+  ./deploy.sh
+  ```
+
+  The script performs `git pull --rebase`, installs production dependencies for
+  the backend and frontend, rebuilds the Vite bundle and reloads PM2 using the
+  tracked ecosystem configuration.

--- a/backend-auth/ecosystem.config.js
+++ b/backend-auth/ecosystem.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  apps: [
+    {
+      name: 'patin-api',
+      script: 'server.js',
+      cwd: '/home/deploy/apps/patincarreraGR/backend-auth',
+      instances: 1,
+      exec_mode: 'fork',
+      env: {
+        NODE_ENV: 'production',
+        PORT: 5000
+      },
+      watch: false,
+      time: true,
+      error_file: '/home/deploy/.pm2/logs/patin-api-error.log',
+      out_file: '/home/deploy/.pm2/logs/patin-api-out.log'
+    }
+  ]
+};

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$REPO_ROOT"
+
+echo '>>> Pull repo'
+git fetch --all
+git pull --rebase
+
+echo '>>> Backend deps'
+cd backend-auth
+npm ci --omit=dev
+
+if [ -d ../frontend-auth ]; then
+  echo '>>> Frontend build'
+  cd ../frontend-auth
+  npm ci --omit=dev
+  npm run build
+  cd ../backend-auth
+else
+  cd ../backend-auth
+fi
+
+echo '>>> Restart PM2'
+pm2 startOrReload ecosystem.config.js --update-env
+
+pm2 status patin-api
+


### PR DESCRIPTION
## Summary
- add a PM2 ecosystem configuration file that captures the production runtime settings for patin-api
- create a deploy.sh helper to fetch updates, reinstall production dependencies, rebuild the frontend, and reload PM2 in one step
- document the new deployment workflow and script usage in DEPLOYMENT.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b265b7d083208219150c6205d9dc