### PR TITLE
Center page titles across the app

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -19,6 +19,13 @@ body {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
+/* Center the default page headings across the app */
+h1,
+h2,
+h3 {
+  text-align: center;
+}
+
 .navbar {
   background-color: var(--primary-color) !important;
   transition: background-color 0.3s ease;


### PR DESCRIPTION
## Summary
- center the default page heading elements by adding a global CSS rule

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7544f3e248320822f8d2326ff7210