### PR TITLE
Add operational health endpoint for API

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -262,6 +262,27 @@ app.use((err, req, res, next) => {
 app.use('/uploads', express.static(UPLOADS_DIR));
 app.use('/api/uploads', express.static(UPLOADS_DIR));
 
+const mongoConnectionStates = {
+  0: 'disconnected',
+  1: 'connected',
+  2: 'connecting',
+  3: 'disconnecting'
+};
+
+app.get('/api/health', (_req, res) => {
+  const connectionState = mongoose.connection.readyState;
+  const isDatabaseConnected = connectionState === 1;
+
+  res
+    .status(isDatabaseConnected ? 200 : 503)
+    .set('Cache-Control', 'no-store')
+    .json({
+      status: isDatabaseConnected ? 'ok' : 'degraded',
+      uptime: process.uptime(),
+      database: mongoConnectionStates[connectionState] ?? 'unknown'
+    });
+});
+
 
 const CODIGO_DELEGADO = process.env.CODIGO_DELEGADO || 'DEL123';
 const CODIGO_TECNICO = process.env.CODIGO_TECNICO || 'TEC456';


### PR DESCRIPTION
## Summary
- add a dedicated /api/health route that reports service uptime and MongoDB connection state
- disable caching on the health response so monitors always receive fresh status

## Testing
- node backend-auth/server.js
- curl -i http://127.0.0.1:5000/api/health

------
https://chatgpt.com/codex/tasks/task_e_68da9853b604832091b1efc0e2a2f94d