### PR TITLE
Fix production fallbacks for non-HTTPS deployment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,7 +22,7 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    cp .env.example .env
    # edit .env with real values (Mongo URI, JWT secret, email creds, etc.)
    # NODE_ENV=production (present in the example file) ensures the backend
-   # uses https://patincarrera.net as the default domain for redirects & CORS.
+   # uses http://patincarrera.net as the default domain for redirects & CORS.
    npm install
    # PM2 is now configured via backend-auth/ecosystem.config.js so we can
    # keep the runtime options under version control. The file assumes the

--- a/backend-auth/config/passport.js
+++ b/backend-auth/config/passport.js
@@ -9,11 +9,11 @@ passport.use(new GoogleStrategy({
   callbackURL:
     process.env.GOOGLE_REDIRECT_URI ||
 
-    'https://patincarrera.net/api/auth/google/callback'
+    'http://patincarrera.net/api/auth/google/callback'
 
 
     (process.env.NODE_ENV === 'production'
-      ? 'https://patincarrera.net/api/auth/google/callback'
+      ? 'http://patincarrera.net/api/auth/google/callback'
       : 'http://localhost:5000/api/auth/google/callback')
   
 

--- a/backend-auth/routes/protegidas.js
+++ b/backend-auth/routes/protegidas.js
@@ -7,7 +7,7 @@ const upload = require('../utils/multer');
 // Base URL of the backend, used when returning file paths.
 const DEFAULT_BACKEND_URL =
   process.env.NODE_ENV === 'production'
-    ? 'https://patincarrera.net'
+    ? 'http://patincarrera.net'
     : 'http://localhost:5000';
 
 const BACKEND_URL = (process.env.BACKEND_URL || DEFAULT_BACKEND_URL).replace(/\/+$/, '');

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -129,18 +129,20 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 const DEFAULT_ALLOWED_ORIGINS = [
   'http://localhost:5173',
+  'http://patincarrera.net',
+  'http://www.patincarrera.net',
   'https://patincarrera.net',
   'https://www.patincarrera.net'
 ];
 
 const FALLBACK_FRONTEND_URL = isProduction
-  ? 'https://patincarrera.net'
+  ? 'http://patincarrera.net'
   : 'http://localhost:5173';
 const FALLBACK_FRONTEND_URL_WWW = isProduction
-  ? 'https://www.patincarrera.net'
+  ? 'http://www.patincarrera.net'
   : 'http://localhost:5173';
 const FALLBACK_BACKEND_URL = isProduction
-  ? 'https://patincarrera.net'
+  ? 'http://patincarrera.net'
   : 'http://localhost:5000';
 
 const FRONTEND_URL = (process.env.FRONTEND_URL || FALLBACK_FRONTEND_URL).replace(/\/+$/, '');
@@ -1870,7 +1872,7 @@ app.get('/api/progreso/:id', protegerRuta, async (req, res) => {
 app.get('/api/auth/google', (req, res) => {
   const redirectUri =
     process.env.GOOGLE_REDIRECT_URI ||
-    'https://patincarrera.net/api/auth/google/callback';
+    'http://patincarrera.net/api/auth/google/callback';
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID || '',
     redirect_uri: redirectUri,
@@ -1892,7 +1894,7 @@ app.get('/api/auth/google/callback', async (req, res) => {
   try {
     const redirectUri =
       process.env.GOOGLE_REDIRECT_URI ||
-      'https://patincarrera.net/api/auth/google/callback';
+      'http://patincarrera.net/api/auth/google/callback';
     const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/frontend-auth/src/utils/getImageUrl.js
+++ b/frontend-auth/src/utils/getImageUrl.js
@@ -30,12 +30,16 @@ export default function getImageUrl(rawPath) {
   const normalizeHost = (host) => host?.replace(/^www\./i, '') || '';
 
   let backendHost = '';
+  let backendProtocol = '';
   try {
-    backendHost = normalizeHost(new URL(base).hostname);
+    const backendUrl = new URL(base);
+    backendHost = normalizeHost(backendUrl.hostname);
+    backendProtocol = backendUrl.protocol;
   } catch (error) {
     console.warn('No se pudo determinar el host base para las imágenes.', error);
   }
   const currentHost = normalizeHost(window.location.hostname);
+  const isPageServedOverHttps = window.location.protocol === 'https:';
 
   // Las URLs absolutas son válidas siempre que no apunten a hosts locales
   // (como `http://localhost:5000`) que quedan inaccesibles en producción.
@@ -53,7 +57,8 @@ export default function getImageUrl(rawPath) {
         (candidateHost === backendHost || candidateHost === currentHost);
       const shouldRewriteHttpSameDomain =
         parsed.protocol === 'http:' &&
-        isSameBackendHost;
+        isSameBackendHost &&
+        (backendProtocol === 'https:' || isPageServedOverHttps);
       const pathWithoutLeadingSlash = parsed.pathname.replace(/^\/+/, '');
       const isUploadPath = /^((api\/)?uploads\/)/i.test(pathWithoutLeadingSlash);
 


### PR DESCRIPTION
## Summary
- default production URLs now use http://patincarrera.net so redirects work without TLS
- broaden CORS defaults to include both HTTP and HTTPS origins
- avoid forcing HTTPS image URLs unless the site itself is served over HTTPS

## Testing
- npm test (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68db45721bac8320b84dac253c522ddc