### PR TITLE
Align deployment configuration for production readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
-node_modules
-frontend-auth/node_modules
-backend-auth/node_modules
+node_modules/
+frontend-auth/node_modules/
+backend-auth/node_modules/
 backend-auth/usuarios.db
+
+# Build artifacts
+frontend-auth/dist/
+
+# Environment files
 .env
+*.env.local
 backend-auth/.env
-frontend-auth/.env
+frontend-auth/.env*
+!frontend-auth/.env.production

--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -1,16 +1,16 @@
 {
   "name": "backend-auth",
   "version": "1.0.0",
-  "type": "commonjs",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
     "dev": "NODE_ENV=development nodemon server.js",
     "health": "curl -i http://127.0.0.1:5000/api/health || true"
   },
-  
-  "engines": { "node": ">=18 <22" },
-
+  "engines": {
+    "node": ">=18 <22"
+  },
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -27,14 +27,9 @@ import pdfToJson from './utils/pdfToJson.js';
 import parseResultadosJson from './utils/parseResultadosJson.js';
 import { comparePasswordWithHash } from './utils/passwordUtils.js';
 
-require('dotenv').config();
-const express = require('express');
-const cors = require('cors');
+dotenv.config();
 
-const ORIGIN = process.env.CLIENT_ORIGIN || 'https://patincarrera.net';
-app.use(cors({ origin: ORIGIN, credentials: true }));
-app.use(express.json());
-app.get('/api/health', (req,res)=>res.status(200).json({ok:true}));
+mongoose.set('strictQuery', true);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -137,12 +132,15 @@ mongoose
 const isProduction = process.env.NODE_ENV === 'production';
 
 
+const CLIENT_ORIGIN = (process.env.CLIENT_ORIGIN || 'https://patincarrera.net').replace(/\/+$/, '');
+
 const DEFAULT_ALLOWED_ORIGINS = [
   'http://localhost:5173',
   'http://patincarrera.net',
   'http://www.patincarrera.net',
   'https://patincarrera.net',
-  'https://www.patincarrera.net'
+  'https://www.patincarrera.net',
+  CLIENT_ORIGIN
 ];
 
 const FALLBACK_FRONTEND_URL = isProduction

--- a/frontend-auth/.env.production
+++ b/frontend-auth/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE=https://patincarrera.net/api

--- a/frontend-auth/package-lock.json
+++ b/frontend-auth/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-auth",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-auth",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "axios": "^1.8.4",
         "exceljs": "^4.4.0",

--- a/frontend-auth/package.json
+++ b/frontend-auth/package.json
@@ -1,13 +1,13 @@
 {
   "name": "frontend-auth",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview --port 4173"
   },
   "dependencies": {
     "axios": "^1.8.4",

--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -4,7 +4,8 @@ import axios from 'axios';
 // values received from the environment so every deployment ends up
 // calling the backend under the expected `/api` prefix.
 const buildApiBaseUrl = () => {
-  const rawEnvUrl = import.meta.env.VITE_API_URL?.trim();
+  const rawEnvUrl =
+    import.meta.env.VITE_API_BASE?.trim() || import.meta.env.VITE_API_URL?.trim();
 
   if (rawEnvUrl) {
     const normalised = rawEnvUrl.replace(/\/+$/, '');
@@ -34,12 +35,9 @@ const buildApiBaseUrl = () => {
 
 
 
-// const api = axios.create({
-//   baseURL: buildApiBaseUrl()
-// });
-
 const api = axios.create({
   baseURL: buildApiBaseUrl(),
+  withCredentials: true
 });
 
 


### PR DESCRIPTION
## Summary
- normalise the backend bootstrap to rely on dotenv, enforce strict Mongoose query handling, and expand the CORS allow list with the production origin
- add a checked-in production Vite environment file and update the shared Axios client to honour the configured API base while sending credentials
- tighten repository ignore rules and adjust frontend package metadata to support the deployment workflow

## Testing
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68dbdb00ef9883208e254bb2c91e804e