### PR TITLE
Fix API base URL resolution to prevent login 404

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -1,5 +1,23 @@
 import axios from 'axios';
 
+const ensureApiSuffix = (value) => {
+  if (!value) return null;
+  const trimmed = value.replace(/\/+$/, '');
+  return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
+};
+
+const resolveConfiguredBase = (rawUrl, origin) => {
+  try {
+    const resolved = new URL(rawUrl, origin);
+    resolved.hash = '';
+    resolved.search = '';
+    const basePath = resolved.pathname.replace(/\/+$/, '');
+    return ensureApiSuffix(`${resolved.origin}${basePath}`);
+  } catch {
+    return null;
+  }
+};
+
 // Build the base URL used by the Axios instance. The helper normalises
 // values received from the environment so every deployment ends up
 // calling the backend under the expected `/api` prefix.
@@ -7,10 +25,29 @@ const buildApiBaseUrl = () => {
   const rawEnvUrl =
     import.meta.env.VITE_API_BASE?.trim() || import.meta.env.VITE_API_URL?.trim();
 
+  const isBrowser = typeof window !== 'undefined';
+
   if (rawEnvUrl) {
-    const normalised = rawEnvUrl.replace(/\/+$/, '');
-    return normalised.endsWith('/api') ? normalised : `${normalised}/api`;
+    if (!isBrowser) {
+      const direct = ensureApiSuffix(rawEnvUrl);
+      if (direct) return direct;
+    } else {
+      const configured = resolveConfiguredBase(rawEnvUrl, window.location.origin);
+      if (configured) {
+        const configuredUrl = new URL(configured);
+        const hostMatches = configuredUrl.origin === window.location.origin;
+        const isLocalHost = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/i.test(
+          window.location.hostname
+        );
+
+        if (hostMatches || import.meta.env.DEV || isLocalHost) {
+          return configured;
+        }
+      }
+    }
   }
+
+  if (!isBrowser) return '/api';
 
   const backendPort = import.meta.env.VITE_BACKEND_PORT?.trim();
   const { protocol, hostname, origin } = window.location;
@@ -32,8 +69,6 @@ const buildApiBaseUrl = () => {
   const normalisedOrigin = origin.replace(/\/+$/, '');
   return `${normalisedOrigin}/api`;
 };
-
-
 
 const api = axios.create({
   baseURL: buildApiBaseUrl(),


### PR DESCRIPTION
## Summary
- update the Axios base-URL builder to normalise configured URLs and prefer the current origin in production when the configured host differs
- keep development overrides for localhost environments while ensuring all deployments consistently target the `/api` prefix

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde4ff9d008320ba093cca04ce1217