### PR TITLE
Fix API base URL resolution for cross-domain deployments

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -28,22 +28,13 @@ const buildApiBaseUrl = () => {
   const isBrowser = typeof window !== 'undefined';
 
   if (rawEnvUrl) {
-    if (!isBrowser) {
-      const direct = ensureApiSuffix(rawEnvUrl);
-      if (direct) return direct;
-    } else {
-      const configured = resolveConfiguredBase(rawEnvUrl, window.location.origin);
-      if (configured) {
-        const configuredUrl = new URL(configured);
-        const hostMatches = configuredUrl.origin === window.location.origin;
-        const isLocalHost = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/i.test(
-          window.location.hostname
-        );
+    const normalised = ensureApiSuffix(rawEnvUrl);
 
-        if (hostMatches || import.meta.env.DEV || isLocalHost) {
-          return configured;
-        }
-      }
+    if (!isBrowser) {
+      if (normalised) return normalised;
+    } else {
+      const configured = resolveConfiguredBase(rawEnvUrl, window.location.origin) || normalised;
+      if (configured) return configured;
     }
   }
 


### PR DESCRIPTION
## Summary
- update the Axios API helper to always honour the configured backend URL so it works when the frontend and backend use different hosts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddeb003e388320920c77d4d24d2237