### PR TITLE
Ensure server derives __dirname with explicit __filename

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -33,7 +33,8 @@ import { comparePasswordWithHash } from './utils/passwordUtils.js';
 dotenv.config();
 
 // --------- Paths / TZ ---------
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 process.env.TZ = 'America/Argentina/Buenos_Aires';
 
 // --------- Uploads dir ---------


### PR DESCRIPTION
## Summary
- derive `__dirname` from an explicit `__filename` in the backend auth server so the uploads path configuration matches the documented snippet

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df2b743e7083209a82c2f2908d4fa9