### PR TITLE
Serve uploads from legacy directories

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -21,6 +21,9 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    cd backend-auth
    cp .env.example .env
    # edit .env with real values (Mongo URI, JWT secret, email creds, etc.)
+   # UPLOADS_DIR defaults to backend-auth/uploads. If you have legacy
+   # assets in another directory you can list them in
+   # UPLOADS_FALLBACK_DIRS=/ruta/vieja/uploads
    # NODE_ENV=production (present in the example file) ensures the backend
    # uses http://patincarrera.net as the default domain for redirects & CORS.
    npm install

--- a/backend-auth/.env.example
+++ b/backend-auth/.env.example
@@ -4,6 +4,10 @@ JWT_SECRET=change_me
 FRONTEND_URL=https://patincarrera.net
 FRONTEND_URL_WWW=https://www.patincarrera.net
 BACKEND_URL=https://patincarrera.net
+UPLOADS_DIR=/home/deploy/apps/patincarreraGR/backend-auth/uploads
+# Directorios adicionales separados por coma o punto y coma para archivos históricos.
+# Ejemplo: UPLOADS_FALLBACK_DIRS=/home/deploy/apps/patincarreraGR/backend/uploads
+UPLOADS_FALLBACK_DIRS=
 PORT=5000
 CODIGO_DELEGADO=DEL123
 CODIGO_TECNICO=TEC456


### PR DESCRIPTION
## Summary
- allow the backend to resolve uploads from multiple directories so legacy files remain accessible
- document the new UPLOADS_DIR and UPLOADS_FALLBACK_DIRS environment variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2e22dd148320aa96fd90642aa7da