### PR TITLE
Serve uploads via public path

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,6 +24,9 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    # UPLOADS_DIR defaults to backend-auth/uploads. If you have legacy
    # assets in another directory you can list them in
    # UPLOADS_FALLBACK_DIRS=/ruta/vieja/uploads
+   # PUBLIC_UPLOADS_PATH defaults to /uploads and must match the path that
+   # Nginx exposes in its static file location. Leave it untouched unless you
+   # intentionally expose the assets under a different public prefix.
    # NODE_ENV=production (present in the example file) ensures the backend
    # uses http://patincarrera.net as the default domain for redirects & CORS.
    npm install
@@ -59,7 +62,9 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    sudo ln -s /etc/nginx/sites-available/patincarrera /etc/nginx/sites-enabled/
    # If you placed the frontend bundle in a different directory, edit the
    # server block and update the `root` directive accordingly before
-   # restarting Nginx.
+   # restarting Nginx. Ensure the `alias` directive for `/uploads/` matches
+   # the absolute path of the backend `uploads` directory (defaults to
+   # /var/www/patincarrera/backend/uploads/ when following this guide).
    sudo nano /etc/nginx/sites-available/patincarrera
    sudo nginx -t
    sudo systemctl restart nginx

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -26,14 +26,29 @@ server {
         proxy_buffering off;
     }
 
-    # Expose profile pictures and other uploaded assets handled by Express.
-    location /api/uploads/ {
-        proxy_pass http://127.0.0.1:5000/api/uploads/;
+    # Serve uploaded assets directly from disk. Files that do not exist on the
+    # filesystem fall back to Express so older uploads stored outside of the
+    # main directory can still be resolved.
+    location /uploads/ {
+        alias /var/www/patincarrera/backend/uploads/;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri $uri/ @uploads_api_fallback;
+    }
+
+    location @uploads_api_fallback {
+        internal;
+        proxy_pass http://127.0.0.1:5000/api$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Backwards compatibility: redirect legacy `/api/uploads/*` URLs to the new
+    # public path handled above so bookmarks keep working.
+    location /api/uploads/ {
+        rewrite ^/api/uploads/(.*)$ /uploads/$1 permanent;
     }
 
     location / {

--- a/frontend-auth/vite.config.js
+++ b/frontend-auth/vite.config.js
@@ -9,6 +9,10 @@ export default defineConfig({
   // proxy connection issues.
   server: {
     proxy: {
+      '/uploads': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      },
       '/api/uploads': {
         target: 'http://localhost:5000',
         changeOrigin: true


### PR DESCRIPTION
## Summary
- add a configurable PUBLIC_UPLOADS_PATH helper in the backend so generated URLs point to /uploads and expose the same route alongside the existing /api/uploads fallback
- update the protected routes module, frontend image URL normaliser, and Vite proxy so the UI always requests assets through the new public uploads prefix
- adjust the deployment guide and nginx.conf to serve files directly from disk with a proxy fallback for historical locations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3bd9cbb388320bbd894ef99bc148c