### PR TITLE
Allow delegates to manage club titles

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -110,11 +110,11 @@ function AppRoutes() {
           <Route path="/notificaciones" element={<ProtectedRoute><Notificaciones /></ProtectedRoute>} />
           <Route
             path="/titulos-club"
-            element={<ProtectedRoute roles={['Delegado']}><TitulosClub /></ProtectedRoute>}
+            element={<ProtectedRoute><TitulosClub /></ProtectedRoute>}
           />
           <Route
             path="/titulos-club/:id"
-            element={<ProtectedRoute roles={['Delegado']}><VerTituloClub /></ProtectedRoute>}
+            element={<ProtectedRoute><VerTituloClub /></ProtectedRoute>}
           />
           <Route
             path="/seguros"

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -133,6 +133,7 @@ export default function Navbar() {
     ? [
         { label: 'Inicio', path: '/home' },
         { label: 'Torneos', path: '/torneos' },
+        { label: 'Títulos del Club', path: '/titulos-club' },
         ...(rol === 'Tecnico'
           ? [
               { label: 'Entrenamientos', path: '/entrenamientos' },
@@ -144,9 +145,6 @@ export default function Navbar() {
           : []),
         ...(rol === 'Delegado'
           ? [{ label: 'Seguros', path: '/seguros' }]
-          : []),
-        ...(rol === 'Delegado'
-          ? [{ label: 'Títulos del Club', path: '/titulos-club' }]
           : []),
         ...(rol === 'Delegado' || rol === 'Tecnico'
           ? [


### PR DESCRIPTION
## Summary
- add update and delete endpoints so delegates can manage club titles from the API
- allow every authenticated role to access the club titles views and navigation entry
- enhance the club titles page with delegate-only edit/delete tooling alongside the existing creation form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e907e250288320a0651f5750df90bb