### PR TITLE
Display club logo in navbar

### DIFF
--- a/frontend-auth/src/components/LogoutButton.jsx
+++ b/frontend-auth/src/components/LogoutButton.jsx
@@ -8,6 +8,8 @@ export default function LogoutButton() {
     sessionStorage.removeItem('rol');
     sessionStorage.removeItem('foto');
     sessionStorage.removeItem('clubId');
+    sessionStorage.removeItem('clubLogo');
+    sessionStorage.removeItem('clubNombre');
     navigate('/');
   };
 


### PR DESCRIPTION
## Summary
- load the current club data when a user is authenticated so the navbar can access the club logo
- render the club logo (with a fallback image) in the navbar brand and cache the name/logo for reuse
- clear cached club metadata from session storage on logout to avoid stale branding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eae3ed3edc8320bcf256fdda9ac7f1