### PR TITLE
Update federation section heading and remove contact details

### DIFF
--- a/frontend-auth/src/pages/Home.jsx
+++ b/frontend-auth/src/pages/Home.jsx
@@ -430,7 +430,9 @@ export default function Home() {
       )}
       {federacionesParaMostrar.length > 0 && (
         <div className="container mb-5">
-          <h2 className="text-center mb-4">Federaciones asociadas a la CAP</h2>
+          <h2 className="text-center mb-4">
+            {`AFILIADO A "${federacionesParaMostrar[0].nombre}".`}
+          </h2>
           <div className="row g-4">
             {federacionesParaMostrar.map((federacion) => (
               <div className="col-12 col-md-6 col-lg-4" key={federacion._id}>
@@ -440,20 +442,17 @@ export default function Home() {
                     {federacion.descripcion && (
                       <p className="card-text flex-grow-1">{federacion.descripcion}</p>
                     )}
-                    {(federacion.sitioWeb || federacion.contacto) && (
+                    {federacion.sitioWeb && (
                       <ul className="list-unstyled small mb-0 mt-3">
-                        {federacion.sitioWeb && (
-                          <li>
-                            <a
-                              href={normaliseFederationUrl(federacion.sitioWeb)}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              {federacion.sitioWeb}
-                            </a>
-                          </li>
-                        )}
-                        {federacion.contacto && <li>{federacion.contacto}</li>}
+                        <li>
+                          <a
+                            href={normaliseFederationUrl(federacion.sitioWeb)}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {federacion.sitioWeb}
+                          </a>
+                        </li>
                       </ul>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- update the federations section heading to display the affiliation message with the current federation name
- remove contact details from the federation cards while keeping the website link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebdf8e56708320bb641b86418c95f8