### PR TITLE
Adjust news card labels sizing and gradient

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -526,11 +526,13 @@ body.dark-mode .btn-primary {
 .news-item.bottom-right .image-container {
   height: 200px;
 }
+
 .news-item .image-container {
   position: relative;
   height: 200px;
   overflow: hidden;
   border-radius: inherit;
+  --label-width: clamp(110px, 33%, 160px);
 }
 
 
@@ -538,38 +540,41 @@ body.dark-mode .btn-primary {
   position: absolute;
   bottom: 0;
   left: 0;
-  width: 25%;
+  width: var(--label-width);
   height: 34px;
   background: linear-gradient(90deg, var(--secondary-color) 0%, rgba(20, 86, 150, 0.85) 100%);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: clamp(0.55rem, 1vw, 0.7rem);
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   clip-path: polygon(0 0, calc(100% - 11px) 0, 100% 100%, 0 100%);
   border-top-left-radius: 0.25rem;
   border-bottom-left-radius: 0.25rem;
+  padding: 0 0.5rem;
+  white-space: nowrap;
 }
 
 .news-item .news-label-line {
   position: absolute;
   bottom: 0;
-  left: 25%;
-  width: 75%;
+  left: var(--label-width);
+  width: calc(100% - var(--label-width));
   height: 6px;
-  background: linear-gradient(90deg, rgba(126, 163, 68, 0.9) 0%, rgba(20, 86, 150, 0.65) 100%);
+  background: linear-gradient(270deg, rgba(126, 163, 68, 0.9) 0%, rgba(20, 86, 150, 0.65) 100%);
 }
 
 .news-item .competition-label {
-  width: 40%;
+  --label-width: clamp(130px, 45%, 200px);
+  font-size: clamp(0.5rem, 0.9vw, 0.65rem);
+  letter-spacing: 0.06em;
 }
 
 .news-item .competition-label + .news-label-line {
-  left: 40%;
-  width: 60%;
+  --label-width: clamp(130px, 45%, 200px);
 }
 
 


### PR DESCRIPTION
## Summary
- expand news card label sizing to use clamp-based custom properties so long titles fit without overflowing
- reduce label typography spacing and add padding for better readability on both news and competition cards
- flip the accompanying gradient line direction by updating its background gradient angle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee1ccdc6e8832098d2c40f4361bded