### PR TITLE
Fix backend startup by removing duplicate helper definition

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -678,9 +678,6 @@ const pickNonEmptyString = (...values) => {
   return '';
 };
 
-const escapeRegExp = (value) =>
-  value.replace(/[.*+?^${}()|\[\]\\]/g, '\$&');
-
 const trimmedOrNull = (value) => {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();


### PR DESCRIPTION
## Summary
- remove the duplicate `escapeRegExp` helper declaration so the backend can boot without syntax errors

## Testing
- npm run health *(fails with 503 because the local MongoDB instance is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef71cca0b48320806ea3fbb84803ed