### PR TITLE
Improve tournament result PDF import robustness

### DIFF
--- a/backend-auth/utils/pdfToJson.js
+++ b/backend-auth/utils/pdfToJson.js
@@ -2,21 +2,44 @@ import pdf from 'pdf-parse/lib/pdf-parse.js';
 import fs from 'fs';
 import path from 'path';
 
-// Nota: pdf-parse usa internamente pdf.js. Intentar ajustar la verbosidad
-// provocaba errores en tiempo de ejecución, por lo que se utiliza la
-// configuración predeterminada sin modificar la salida de logs de pdf.js.
+const sanitizeLineBreaks = (text) => {
+  if (typeof text !== 'string') return '';
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+};
+
+const normaliseLine = (line) => {
+  if (typeof line !== 'string') return '';
+  return line.replace(/\u00a0/g, ' ');
+};
+
+const buildJsonPayload = (rawText) => {
+  const normalisedText = sanitizeLineBreaks(rawText || '');
+  const rawLines = normalisedText.split('\n').map((line) => normaliseLine(line));
+  const trimmedLines = rawLines.map((line) => line.trim()).filter(Boolean);
+
+  return {
+    lines: trimmedLines,
+    rawLines,
+    metadata: {
+      totalLines: rawLines.length,
+      nonEmptyLines: trimmedLines.length,
+      textLength: normalisedText.length,
+      usedOCR: false
+    }
+  };
+};
 
 // Convierte el contenido de un PDF a un objeto JSON y opcionalmente lo guarda en disco.
 //
 // buffer: contenido del archivo PDF en memoria.
 // outputPath: ruta donde se guardará el archivo JSON generado. Si se omite, solo devuelve el objeto.
 export default async function pdfToJson(buffer, outputPath) {
+  if (!buffer || buffer.length === 0) {
+    throw new Error('El PDF está vacío o no se recibió correctamente.');
+  }
+
   const data = await pdf(buffer, { max: 0 });
-  const lines = data.text
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean);
-  const json = { lines };
+  const json = buildJsonPayload(data?.text || '');
 
   if (outputPath) {
     const dir = path.dirname(outputPath);


### PR DESCRIPTION
## Summary
- enhance PDF parsing utilities to preserve raw lines and expose metadata for diagnostics
- make result extraction more tolerant to varied table layouts while reporting per-line errors
- extend the import endpoint with detailed logging, fuzzy name matching, transactional writes, and richer summaries for the frontend

## Testing
- `node - <<'NODE'
import parseResultadosJson from './backend-auth/utils/parseResultadosJson.js';

const sample = {
  rawLines: [
    'CATEGORIA: CHUPETE',
    '1   12   GOMEZ MARIA    CLUB LOCAL    10',
    '2   15   PEREZ JUAN     CLUB LOCAL    8',
    'CATEGORIA PREINFANTIL',
    '1   22   LOPEZ ANA      CLUB INVITADO    9'
  ]
};

console.log(parseResultadosJson(sample));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68f0bffbe234832088bd53080121dcd1