### PR TITLE
Handle missing categories during PDF result import

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -2610,9 +2610,15 @@ app.post('/api/competitions/:id/resultados/import-pdf', protegerRuta, permitirRo
         let patinador = null;
         let matchType = null;
         let matchScore = null;
+        const categoriaParseada = fila.categoria || null;
+        const categoriaInferida = fila.categoriaInferida || null;
 
         if (dorsalNumber !== null) {
-          const candidato = findPatinadorByDorsalIndex(indexes, dorsalNumber, fila.categoria);
+          const candidato = findPatinadorByDorsalIndex(
+            indexes,
+            dorsalNumber,
+            categoriaParseada || categoriaInferida
+          );
           if (candidato) {
             patinador = candidato;
             matchType = 'dorsal';
@@ -2643,7 +2649,8 @@ app.post('/api/competitions/:id/resultados/import-pdf', protegerRuta, permitirRo
         if (matchType === 'dorsal') coincidenciasPorDorsal += 1;
         if (matchType === 'nombre') coincidenciasPorNombre += 1;
 
-        const categoriaResultado = fila.categoria || patinador.categoria;
+        const categoriaResultado =
+          categoriaParseada || categoriaInferida || patinador.categoria;
         const dorsalDisplay = String(fila.dorsal ?? '').trim() || String(patinador.numeroCorredor || dorsalNumber || '');
         const puntosValor = Number.isFinite(fila.puntos) ? fila.puntos : 0;
 


### PR DESCRIPTION
## Summary
- allow the PDF parser to retain rows even when the category could not be read directly
- infer categories from previous context when possible and surface rows without category in the metadata
- use the inferred category information during result matching so rows without an explicit category still import

## Testing
- npm test -- --watchAll=false *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68f180e2d5a88320b11d6c7f4af8892c