### PR TITLE
Adjust dorsal selection when importing PDF results

### DIFF
--- a/backend-auth/utils/parseResultadosJson.js
+++ b/backend-auth/utils/parseResultadosJson.js
@@ -58,7 +58,25 @@ const parseColumnsRow = (columns, contexto) => {
   const posicion = Number.parseInt(ordenRaw, 10);
   if (Number.isNaN(posicion)) return null;
 
-  const dorsal = dorsalRaw;
+  const dorsal = (() => {
+    if (valores.length >= 3) {
+      const bloques = [];
+      for (let i = 0; i <= valores.length - 3; i += 1) {
+        const posibleDorsal = valores[i];
+        const posiblePos = valores[i + 1];
+        const posiblePuntos = valores[i + 2];
+        if (!posibleDorsal) continue;
+        if (!isNumeric(posiblePos) || !isNumeric(posiblePuntos)) continue;
+        bloques.push({ dorsal: posibleDorsal, index: i });
+      }
+      if (bloques.length > 0) {
+        const preferido = String(bloques[bloques.length - 1].dorsal || '').trim();
+        if (preferido) return preferido;
+      }
+    }
+  
+    return dorsalRaw;
+  })();
   const valores = [...rest];
   const puntosIndex = (() => {
     for (let i = valores.length - 1; i >= 0; i -= 1) {


### PR DESCRIPTION
## Summary
- update the PDF results parser to ignore duplicated dorsal columns and prefer the last scoring block when selecting the competitor number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f288303fac8320acd34796cd1e411e