### PR TITLE
Handle missing roster when importing PDF results

### DIFF
--- a/backend-auth/utils/parseResultadosJson.js
+++ b/backend-auth/utils/parseResultadosJson.js
@@ -58,8 +58,32 @@ const parseColumnsRow = (columns, contexto) => {
   const posicion = Number.parseInt(ordenRaw, 10);
   if (Number.isNaN(posicion)) return null;
 
-  const dorsal = dorsalRaw;
   const valores = [...rest];
+  const dorsal = (() => {
+    if (valores.length >= 3) {
+      const bloques = [];
+      for (let i = 0; i <= valores.length - 3; i += 1) {
+        const posibleDorsal = valores[i];
+        const posiblePos = valores[i + 1];
+        const posiblePuntos = valores[i + 2];
+        if (!posibleDorsal) continue;
+        if (!isNumeric(posiblePos) || !isNumeric(posiblePuntos)) continue;
+        bloques.push({ dorsal: posibleDorsal, index: i });
+      }
+      if (bloques.length > 0) {
+        const preferido = bloques[bloques.length - 1];
+        if (preferido) {
+          const normalizado = String(preferido.dorsal || '').trim();
+          if (normalizado) {
+            valores.splice(preferido.index, 3);
+            return normalizado;
+          }
+        }
+      }
+    }
+
+    return dorsalRaw;
+  })();
   const puntosIndex = (() => {
     for (let i = valores.length - 1; i >= 0; i -= 1) {
       if (isNumeric(valores[i])) return i;


### PR DESCRIPTION
## Summary
- normalise parsed PDF rows by keeping the last dorsal block and ignoring duplicated columns
- create or update PatinadorExterno records when the roster is missing so PDF imports still persist results
- normalise names and club data from the PDF to reuse invitado records and associate club documents during import

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f288303fac8320acd34796cd1e411e