### PR TITLE
Fix duplicate dorsal constant in results parser

### DIFF
--- a/backend-auth/utils/parseResultadosJson.js
+++ b/backend-auth/utils/parseResultadosJson.js
@@ -59,26 +59,6 @@ const parseColumnsRow = (columns, contexto) => {
   if (Number.isNaN(posicion)) return null;
 
 
-  const dorsal = (() => {
-    if (valores.length >= 3) {
-      const bloques = [];
-      for (let i = 0; i <= valores.length - 3; i += 1) {
-        const posibleDorsal = valores[i];
-        const posiblePos = valores[i + 1];
-        const posiblePuntos = valores[i + 2];
-        if (!posibleDorsal) continue;
-        if (!isNumeric(posiblePos) || !isNumeric(posiblePuntos)) continue;
-        bloques.push({ dorsal: posibleDorsal, index: i });
-      }
-      if (bloques.length > 0) {
-        const preferido = String(bloques[bloques.length - 1].dorsal || '').trim();
-        if (preferido) return preferido;
-      }
-    }
-  
-    return dorsalRaw;
-  })();
-
   const valores = [...rest];
   const dorsal = (() => {
     if (valores.length >= 3) {


### PR DESCRIPTION
## Summary
- remove the duplicate `dorsal` constant definition in the column parser
- ensure the parser builds its working value array before extracting the dorsal number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f57d0572bc8320ac63b3dee3f213bd