### PR TITLE
Fix Google login redirect URL

### DIFF
--- a/frontend-auth/src/components/LoginForm.jsx
+++ b/frontend-auth/src/components/LoginForm.jsx
@@ -53,7 +53,8 @@ export default function LoginForm() {
   // URL from our Axios instance avoids hard-coding `localhost` and keeps the
   // frontend portable across environments.
   const handleGoogleLogin = () => {
-    window.location.href = `${api.defaults.baseURL}/auth/google`;
+    const baseUrl = (api.defaults.baseURL || '').replace(/\/+$/, '');
+    window.location.href = `${baseUrl}/auth/google`;
   };
 
   return (


### PR DESCRIPTION
## Summary
- avoid generating a double slash when redirecting to the Google OAuth endpoint
- ensure the frontend reuses the configured API base URL without altering the path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f70099b0c48320ba10b8b7da7a69f8