### PR TITLE
Update navbar default branding

### DIFF
--- a/frontend-auth/src/assets/patin-carrera-logo-circle.svg
+++ b/frontend-auth/src/assets/patin-carrera-logo-circle.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <style>
+      .text-primary { font-family: 'Montserrat', 'Segoe UI', sans-serif; font-weight: 700; fill: #003a70; }
+      .text-secondary { font-family: 'Montserrat', 'Segoe UI', sans-serif; font-weight: 600; fill: #004a84; letter-spacing: 6px; }
+    </style>
+  </defs>
+  <circle cx="256" cy="256" r="246" fill="#ffffff" stroke="#8fb14c" stroke-width="20" />
+  <g transform="translate(60 150) scale(0.9)">
+    <g transform="translate(0 55)">
+      <rect x="0" y="-20" width="90" height="12" rx="6" ry="6" fill="#003a70" />
+      <rect x="0" y="2" width="90" height="12" rx="6" ry="6" fill="#003a70" opacity="0.7" />
+      <rect x="0" y="24" width="90" height="12" rx="6" ry="6" fill="#003a70" opacity="0.5" />
+    </g>
+    <g transform="translate(100 0)">
+      <circle cx="65" cy="120" r="55" fill="none" stroke="#003a70" stroke-width="14" />
+      <circle cx="65" cy="120" r="18" fill="#003a70" />
+      <g fill="none" stroke="#003a70" stroke-width="10" stroke-linecap="round">
+        <line x1="65" y1="65" x2="65" y2="95" />
+        <line x1="65" y1="145" x2="65" y2="175" />
+        <line x1="110" y1="120" x2="140" y2="120" />
+        <line x1="-10" y1="120" x2="20" y2="120" />
+        <line x1="101" y1="84" x2="123" y2="62" />
+        <line x1="26" y1="179" x2="48" y2="157" />
+        <line x1="26" y1="61" x2="48" y2="83" />
+        <line x1="101" y1="156" x2="123" y2="178" />
+      </g>
+    </g>
+  </g>
+  <text class="text-primary" font-size="78" x="235" y="225">Patin</text>
+  <text class="text-primary" font-size="78" x="235" y="310">Carrera</text>
+  <text class="text-secondary" font-size="30" x="256" y="382" text-anchor="middle">DONDE EMPIEZA LA VELOCIDAD</text>
+</svg>

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import api from '../api';
 import LogoutButton from './LogoutButton';
 import getImageUrl from '../utils/getImageUrl';
 import placeholderAvatar from '../assets/image-placeholder.svg';
+import defaultBrandLogo from '../assets/patin-carrera-logo-circle.svg';
 
 export default function Navbar() {
   const navigate = useNavigate();
@@ -37,7 +38,7 @@ export default function Navbar() {
   const storedClubName = sessionStorage.getItem('clubNombre') || '';
   const [unread, setUnread] = useState(0);
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
-  const [clubLogo, setClubLogo] = useState(normalisedClubLogo);
+  const [clubLogo, setClubLogo] = useState(normalisedClubLogo || '');
   const [clubName, setClubName] = useState(storedClubName);
   const brandAlt = clubName ? `Logo de ${clubName}` : 'Logo Patín Carrera';
 
@@ -272,7 +273,7 @@ export default function Navbar() {
           style={{ cursor: 'pointer' }}
         >
           <img
-            src={clubLogo || '/vite.svg'}
+            src={clubLogo || defaultBrandLogo}
             alt={brandAlt}
             width="80"
             height="80"


### PR DESCRIPTION
## Summary
- add the Patín Carrera circular logo asset for unauthenticated scenarios
- update the navbar brand to use the default logo when no club logo is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f70492121483208cc06ee39ee3bae9