### PR TITLE
feat: allow administrators to customize default app logo

### DIFF
--- a/backend-auth/models/AppConfig.js
+++ b/backend-auth/models/AppConfig.js
@@ -1,0 +1,50 @@
+import mongoose from 'mongoose';
+
+const APP_CONFIG_KEY = 'app';
+
+const appConfigSchema = new mongoose.Schema(
+  {
+    key: {
+      type: String,
+      unique: true,
+      default: APP_CONFIG_KEY
+    },
+    defaultBrandLogo: {
+      type: String,
+      default: ''
+    }
+  },
+  {
+    timestamps: true
+  }
+);
+
+appConfigSchema.statics.getSingleton = async function getSingleton() {
+  try {
+    const existing = await this.findOne({ key: APP_CONFIG_KEY }).lean();
+    if (existing) return existing;
+
+    const created = await this.create({ key: APP_CONFIG_KEY });
+    return created.toObject();
+  } catch (err) {
+    if (err?.code === 11000) {
+      const recovered = await this.findOne({ key: APP_CONFIG_KEY }).lean();
+      if (recovered) return recovered;
+    }
+    throw err;
+  }
+};
+
+appConfigSchema.statics.updateSingleton = async function updateSingleton(update) {
+  const doc = await this.findOneAndUpdate(
+    { key: APP_CONFIG_KEY },
+    { $set: update, $setOnInsert: { key: APP_CONFIG_KEY } },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+
+  return doc.toObject();
+};
+
+const AppConfig = mongoose.model('AppConfig', appConfigSchema);
+
+export default AppConfig;


### PR DESCRIPTION
## Summary
- add an AppConfig model and backend endpoints to manage the application's default brand logo
- update the navbar to load the configured default logo and react to runtime updates
- extend the admin panel with controls to upload or reset the default logo shown when no club is selected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f70705190483209886024ce8c43a56