### PR TITLE
Ensure featured news image fills its card

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -410,7 +410,7 @@ body.dark-mode .btn-primary {
 .news-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: 400px auto;
+  grid-template-rows: minmax(420px, auto) auto;
   gap: 1.25rem;
   align-items: stretch;
 }
@@ -630,7 +630,7 @@ body.dark-mode .btn-primary {
 .news-item.large {
   display: flex;
   min-height: 420px;
-  align-self: start;
+  align-self: stretch;
   background: radial-gradient(circle at top left, rgba(20, 86, 150, 0.15), transparent 65%);
 }
 
@@ -651,12 +651,14 @@ body.dark-mode .btn-primary {
 .news-item.large .top-news-image {
   flex: 1.5;
   height: 100%;
+  display: flex;
 }
 
 .news-item.large .top-news-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  flex: 1;
   border-radius: inherit;
 }
 


### PR DESCRIPTION
## Summary
- stretch the featured news grid row so the card always matches the row height
- force the featured news image container and image to expand to the full card height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcb99370688320832950725d683aeb