### PR TITLE
Revertir ajustes de tamaño en la tarjeta de noticia destacada

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -410,7 +410,7 @@ body.dark-mode .btn-primary {
 .news-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: minmax(420px, auto) auto;
+  grid-template-rows: 400px auto;
   gap: 1.25rem;
   align-items: stretch;
 }
@@ -630,7 +630,7 @@ body.dark-mode .btn-primary {
 .news-item.large {
   display: flex;
   min-height: 420px;
-  align-self: stretch;
+  align-self: start;
   background: radial-gradient(circle at top left, rgba(20, 86, 150, 0.15), transparent 65%);
 }
 
@@ -651,14 +651,12 @@ body.dark-mode .btn-primary {
 .news-item.large .top-news-image {
   flex: 1.5;
   height: 100%;
-  display: flex;
 }
 
 .news-item.large .top-news-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  flex: 1;
   border-radius: inherit;
 }
 


### PR DESCRIPTION
## Summary
- restablece la altura de las filas del grid de noticias para evitar alargamiento en las tarjetas
- devuelve la alineación y estilos originales de la tarjeta de noticia destacada para la imagen principal

## Testing
- no se realizaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68fcc14ceac88320a1b3399430a76d8a