### PR TITLE
Allow fallback text parsing when Excel sheets missing

### DIFF
--- a/frontend-auth/src/pages/CrearPadron.jsx
+++ b/frontend-auth/src/pages/CrearPadron.jsx
@@ -424,9 +424,29 @@ const parseExcelFile = async (file) => {
     );
   }
 
-  const textContent = isTextLikeFile ? await file.text() : '';
+  let textContent = '';
 
-  if (!textContent || isLikelyBinaryContent(textContent)) {
+  if (isTextLikeFile) {
+    textContent = await file.text();
+  } else if (excelError) {
+    try {
+      const potentialText = await file.text();
+      if (!isLikelyBinaryContent(potentialText)) {
+        textContent = potentialText;
+      }
+    } catch (readError) {
+      console.warn('No fue posible leer el archivo como texto para un análisis alternativo.', readError);
+    }
+  }
+
+  if (!textContent) {
+    throw excelError ||
+      new Error(
+        'El archivo tiene un formato binario no compatible. Exporte la lista nuevamente en formato .xlsx antes de importarla.'
+      );
+  }
+
+  if (isLikelyBinaryContent(textContent)) {
     throw excelError ||
       new Error(
         'El archivo tiene un formato binario no compatible. Exporte la lista nuevamente en formato .xlsx antes de importarla.'


### PR DESCRIPTION
## Summary
- attempt a text-based fallback parse when ExcelJS reports a workbook without sheets
- keep binary detection safeguards and surface a warning if the text fallback cannot be read

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69054e2cf8ac8320b8f84c1c2c22dba5