### PR TITLE
Handle missing user role in login flow

### DIFF
--- a/frontend-auth/src/components/LoginForm.jsx
+++ b/frontend-auth/src/components/LoginForm.jsx
@@ -15,8 +15,16 @@ export default function LoginForm() {
 
       const { token, usuario, needsClubSelection } = res.data;
 
+      const rawRole = typeof usuario.rol === 'string' ? usuario.rol.trim() : '';
+      const normalisedRole = rawRole.toLowerCase();
+
       sessionStorage.setItem('token', token);
-      sessionStorage.setItem('rol', usuario.rol);
+
+      if (rawRole) {
+        sessionStorage.setItem('rol', rawRole);
+      } else {
+        sessionStorage.removeItem('rol');
+      }
 
       if (usuario.club) {
         sessionStorage.setItem('clubId', usuario.club);
@@ -33,13 +41,13 @@ export default function LoginForm() {
         sessionStorage.removeItem('foto');
       }
 
-      if (usuario.rol?.toLowerCase() === 'admin') {
+      if (normalisedRole === 'admin') {
         sessionStorage.removeItem('clubLogo');
         sessionStorage.removeItem('clubNombre');
       }
 
       alert(`Bienvenido ${usuario.nombre}`);
-      if (needsClubSelection && usuario.rol.toLowerCase() !== 'admin') {
+      if (needsClubSelection && normalisedRole !== 'admin') {
         navigate('/seleccionar-club');
       } else {
         navigate('/home');


### PR DESCRIPTION
## Summary
- normalise the user role returned by the backend before using it in the login flow
- avoid storing empty roles in session storage and reuse the cached value when deciding navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905511331c8832095020dabb75bffa9