### PR TITLE
Make competition list responsive

### DIFF
--- a/frontend-auth/src/pages/Competencias.jsx
+++ b/frontend-auth/src/pages/Competencias.jsx
@@ -140,18 +140,18 @@ export default function Competencias() {
       {competencias.length === 0 ? (
         <p>No hay competencias registradas.</p>
       ) : (
-        <ul className="list-group">
+        <ul className="list-group competencias-list">
           {competencias.map((c) => (
-            <li key={c._id} className="list-group-item d-flex justify-content-between align-items-center">
-              <div className="d-flex align-items-center gap-3">
+            <li key={c._id} className="list-group-item competencia-item">
+              <div className="competencia-info">
                 {c.imagen && (
                   <img src={c.imagen} alt="imagen competencia" className="competencia-img" />
                 )}
-                <div>
+                <div className="competencia-info-text">
                   <strong>{c.nombre}</strong> - {new Date(c.fecha).toLocaleDateString()}
                 </div>
               </div>
-              <div className="d-flex gap-2">
+              <div className="competencia-actions">
                 {rol === 'Delegado' && (
                   <>
                     <button

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -834,6 +834,73 @@ body.dark-mode .btn-primary {
   border-radius: 0.25rem;
 }
 
+.competencias-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.competencia-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.competencia-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1 1 280px;
+  min-width: 0;
+}
+
+.competencia-info-text {
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.competencia-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.competencia-actions .btn {
+  min-width: 100px;
+}
+
+@media (max-width: 768px) {
+  .competencia-item {
+    align-items: flex-start;
+  }
+
+  .competencia-info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .competencia-img {
+    width: 100%;
+    max-width: 220px;
+    height: auto;
+    aspect-ratio: 16 / 9;
+  }
+
+  .competencia-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .competencia-actions .btn {
+    flex: 1 1 calc(50% - 0.5rem);
+    min-width: 120px;
+  }
+}
+
 @media (max-width: 768px) {
   .mini-news-container {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- adjust competition list layout to use custom responsive classes
- add responsive styles so competition information and actions wrap gracefully on small screens

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d70090fe08320b978df5f46794542)