### PR TITLE
Make technician reports section responsive

### DIFF
--- a/frontend-auth/src/pages/Reportes.jsx
+++ b/frontend-auth/src/pages/Reportes.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import api from '../api';
 
 export default function Reportes() {
@@ -34,13 +35,51 @@ export default function Reportes() {
     cargarProgresos(id);
   };
 
+  const patinadorSeleccionado = useMemo(
+    () => patinadores.find((p) => p._id === patinadorId),
+    [patinadorId, patinadores]
+  );
+
+  const obtenerDescripcionBreve = (descripcion) => {
+    if (typeof descripcion !== 'string') return '';
+    if (descripcion.length <= 180) return descripcion;
+    return `${descripcion.slice(0, 177)}...`;
+  };
+
+  const obtenerFechaFormateada = (fecha) => {
+    const date = new Date(fecha);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString('es-AR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
+  };
+
+  const obtenerHoraFormateada = (fecha) => {
+    const date = new Date(fecha);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleTimeString('es-AR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    });
+  };
+
   return (
     <div className="container mt-4">
-      <h1 className="mb-4 text-center">Reportes</h1>
-      <div className="mb-3">
-        <label className="form-label">Patinador</label>
-        <select className="form-select" value={patinadorId} onChange={manejarCambio}>
-          <option value="">Seleccione</option>
+      <h1 className="mb-4 text-center">Reportes recibidos</h1>
+      <div className="mb-4">
+        <label className="form-label fw-semibold" htmlFor="patinador-select">
+          Patinador
+        </label>
+        <select
+          id="patinador-select"
+          className="form-select"
+          value={patinadorId}
+          onChange={manejarCambio}
+        >
+          <option value="">Seleccione un patinador</option>
           {patinadores.map((p) => (
             <option key={p._id} value={p._id}>
               {p.primerNombre} {p.apellido}
@@ -48,18 +87,51 @@ export default function Reportes() {
           ))}
         </select>
       </div>
-      {patinadorId && (
+      {patinadorSeleccionado && (
+        <p className="reporte-context text-center mb-4">
+          Mostrando reportes enviados por los técnicos para{' '}
+          <span className="fw-semibold">{`${patinadorSeleccionado.primerNombre} ${patinadorSeleccionado.apellido}`}</span>.
+        </p>
+      )}
+      {patinadorId ? (
         progresos.length > 0 ? (
-          <ul className="list-group">
-            {progresos.map((p) => (
-              <li key={p._id} className="list-group-item">
-                <strong>{new Date(p.fecha).toLocaleDateString('es-AR')}:</strong> {p.descripcion}
-              </li>
+          <div className="reportes-grid">
+            {progresos.map((progreso) => (
+              <article key={progreso._id} className="reporte-card">
+                <header className="reporte-header">
+                  <span className="reporte-date">{obtenerFechaFormateada(progreso.fecha)}</span>
+                  <span
+                    className={`reporte-status ${
+                      progreso.enviado ? 'reporte-status--enviado' : 'reporte-status--pendiente'
+                    }`}
+                  >
+                    {progreso.enviado ? 'Enviado' : 'Pendiente'}
+                  </span>
+                </header>
+                {patinadorSeleccionado && (
+                  <p className="reporte-athlete">{`${patinadorSeleccionado.primerNombre} ${patinadorSeleccionado.apellido}`}</p>
+                )}
+                <p className="reporte-description">
+                  {obtenerDescripcionBreve(progreso.descripcion)}
+                </p>
+                <footer className="reporte-footer">
+                  <Link className="btn btn-primary btn-sm" to={`/reportes/${progreso._id}`}>
+                    Ver reporte completo
+                  </Link>
+                  <span className="reporte-time">{obtenerHoraFormateada(progreso.fecha)}</span>
+                </footer>
+              </article>
             ))}
-          </ul>
+          </div>
         ) : (
-          <p>No hay reportes para este patinador.</p>
+          <div className="reporte-empty">
+            <p className="mb-0">Todavía no recibiste reportes para este patinador.</p>
+          </div>
         )
+      ) : (
+        <div className="reporte-empty">
+          <p className="mb-0">Seleccioná un patinador para ver los reportes enviados por los técnicos.</p>
+        </div>
       )}
     </div>
   );

--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -232,6 +232,136 @@ a:hover {
   box-shadow: 0 0 0 0.2rem rgba(20, 86, 150, 0.25);
 }
 
+.reportes-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.reporte-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 16px 40px rgba(20, 86, 150, 0.12);
+  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reporte-card:hover,
+.reporte-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 50px rgba(20, 86, 150, 0.18);
+}
+
+.reporte-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reporte-date {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--primary-color);
+}
+
+.reporte-status {
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(20, 86, 150, 0.12);
+  color: var(--primary-color);
+}
+
+.reporte-status--enviado {
+  background: rgba(126, 163, 68, 0.18);
+  color: #4b6b1f;
+}
+
+.reporte-status--pendiente {
+  background: rgba(201, 135, 28, 0.18);
+  color: #c9871c;
+}
+
+.reporte-athlete {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--primary-color-dark);
+}
+
+.reporte-description {
+  margin: 0;
+  color: var(--muted-text);
+  line-height: 1.6;
+}
+
+.reporte-footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.reporte-footer .btn {
+  flex-shrink: 0;
+}
+
+.reporte-time {
+  font-size: 0.85rem;
+  color: rgba(15, 13, 14, 0.55);
+  font-weight: 500;
+  letter-spacing: 0.05em;
+}
+
+.reporte-empty {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(20, 86, 150, 0.08);
+  border: 1px dashed rgba(20, 86, 150, 0.25);
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+  color: var(--primary-color);
+}
+
+.reporte-context {
+  color: var(--muted-text);
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 576px) {
+  .reporte-card {
+    padding: 1.25rem;
+  }
+
+  .reporte-footer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .reporte-footer .btn {
+    width: 100%;
+  }
+
+  .reporte-time {
+    text-align: center;
+    width: 100%;
+  }
+}
+
 .footer-custom {
   background: linear-gradient(180deg, rgba(15, 13, 14, 0.95) 0%, rgba(15, 13, 14, 1) 100%);
   border-top: 4px solid rgba(126, 163, 68, 0.6);


### PR DESCRIPTION
## Summary
- redesign the reportes page to show technician updates in responsive cards with clearer metadata and navigation
- add responsive styling for the report cards, including empty states and mobile layout adjustments

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d72e7c0f48320b3bef31676acd48c)