### PR TITLE
Sync footer history with club contact settings

### DIFF
--- a/backend-auth/models/Club.js
+++ b/backend-auth/models/Club.js
@@ -21,7 +21,8 @@ const contactInfoSchema = new mongoose.Schema(
     facebook: { type: String, trim: true },
     instagram: { type: String, trim: true },
     whatsapp: { type: String, trim: true },
-    x: { type: String, trim: true }
+    x: { type: String, trim: true },
+    history: { type: String, trim: true }
   },
   { _id: false }
 );

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -105,7 +105,9 @@ const DEFAULT_LOCAL_CONTACT_INFO = Object.freeze({
   facebook: 'https://www.facebook.com/',
   instagram: 'https://www.instagram.com/stories/patincarrerag.r/',
   whatsapp: '5491173726166',
-  x: 'https://x.com/?lang=es'
+  x: 'https://x.com/?lang=es',
+  history:
+    'En 2021, el Municipio de General Rodríguez creó la Escuela de Patín Carrera como respuesta solidaria al fallecimiento del entrenador que formaba chicos en el Polideportivo Municipal y los llevaba a competir representando al club Social de Paso del Rey. Muchos de esos jóvenes quedaron sin club, y así nació un espacio propio para continuar su desarrollo. Desde entonces, la escuela no dejó de crecer: se afilió a la Asociación de Patinadores Metropolitanos (APM) y participó en torneos nacionales, logrando destacados resultados como el 2.º puesto en el Encuentro Nacional de Escuela y Transición (Moreno, octubre de 2024) y el 3.º puesto en el primer Encuentro Nacional de Escuela y Transición estilo INDOOR (CABA, abril de 2025). Hoy, la Escuela de Patín Carrera de General Rodríguez sigue formando deportistas y consolidando una comunidad en torno al esfuerzo y la velocidad.'
 });
 
 const parseDateOnly = (value) => {
@@ -1015,7 +1017,7 @@ const normaliseUrlOrNull = (value) => {
   return `https://${trimmed}`;
 };
 
-const CONTACT_INFO_KEYS = ['phone', 'email', 'address', 'mapUrl', 'facebook', 'instagram', 'whatsapp', 'x'];
+const CONTACT_INFO_KEYS = ['phone', 'email', 'address', 'mapUrl', 'facebook', 'instagram', 'whatsapp', 'x', 'history'];
 const CONTACT_INFO_URL_KEYS = new Set(['mapUrl', 'facebook', 'instagram', 'x']);
 
 const normaliseContactString = (value) => (typeof value === 'string' ? value.trim() : '');

--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -14,7 +14,9 @@ export default function Footer() {
     facebook: 'https://www.facebook.com/',
     instagram: 'https://www.instagram.com/stories/patincarrerag.r/',
     whatsapp: '5491173726166',
-    x: 'https://x.com/?lang=es'
+    x: 'https://x.com/?lang=es',
+    history:
+      'En 2021, el Municipio de General Rodríguez creó la Escuela de Patín Carrera como respuesta solidaria al fallecimiento del entrenador que formaba chicos en el Polideportivo Municipal y los llevaba a competir representando al club Social de Paso del Rey. Muchos de esos jóvenes quedaron sin club, y así nació un espacio propio para continuar su desarrollo. Desde entonces, la escuela no dejó de crecer: se afilió a la Asociación de Patinadores Metropolitanos (APM) y participó en torneos nacionales, logrando destacados resultados como el 2.º puesto en el Encuentro Nacional de Escuela y Transición (Moreno, octubre de 2024) y el 3.º puesto en el primer Encuentro Nacional de Escuela y Transición estilo INDOOR (CABA, abril de 2025). Hoy, la Escuela de Patín Carrera de General Rodríguez sigue formando deportistas y consolidando una comunidad en torno al esfuerzo y la velocidad.'
   });
 
   const applyContactInfo = useCallback((data = {}) => {
@@ -26,7 +28,8 @@ export default function Footer() {
       facebook: data.facebook || prev.facebook || '',
       instagram: data.instagram || prev.instagram || '',
       whatsapp: data.whatsapp || prev.whatsapp || '',
-      x: data.x || prev.x || ''
+      x: data.x || prev.x || '',
+      history: data.history || prev.history || ''
     }));
   }, []);
 
@@ -78,14 +81,18 @@ export default function Footer() {
     whatsappLink = contactInfo.whatsapp;
   }
 
+  const historyText = (contactInfo.history || '').trim();
+
   const togglePinned = () => {
     const newPinned = !pinned;
     setPinned(newPinned);
-    setHistoryVisible(newPinned);
+    if (historyText) {
+      setHistoryVisible(newPinned);
+    }
   };
 
   const handleMouseEnter = () => {
-    if (!pinned) setHistoryVisible(true);
+    if (!pinned && historyText) setHistoryVisible(true);
   };
 
   const handleMouseLeave = () => {
@@ -125,10 +132,10 @@ export default function Footer() {
                 height="400"
                 className={`robot-image mb-3 ${historyVisible ? 'shift-left' : ''}`}
               />
-              {historyVisible && (
+              {historyVisible && historyText && (
                 <div className="history-bubble">
-                  <p className="mb-0 small">
-                    En 2021, el Municipio de General Rodríguez creó la Escuela de Patín Carrera como respuesta solidaria al fallecimiento del entrenador que formaba chicos en el Polideportivo Municipal y los llevaba a competir representando al club Social de Paso del Rey. Muchos de esos jóvenes quedaron sin club, y así nació un espacio propio para continuar su desarrollo. Desde entonces, la escuela no dejó de crecer: se afilió a la Asociación de Patinadores Metropolitanos (APM) y participó en torneos nacionales, logrando destacados resultados como el 2.º puesto en el Encuentro Nacional de Escuela y Transición (Moreno, octubre de 2024) y el 3.º puesto en el primer Encuentro Nacional de Escuela y Transición estilo INDOOR (CABA, abril de 2025). Hoy, la Escuela de Patín Carrera de General Rodríguez sigue formando deportistas y consolidando una comunidad en torno al esfuerzo y la velocidad.
+                  <p className="mb-0 small" style={{ whiteSpace: 'pre-line' }}>
+                    {historyText}
                   </p>
                 </div>
               )}

--- a/frontend-auth/src/pages/ContactoClub.jsx
+++ b/frontend-auth/src/pages/ContactoClub.jsx
@@ -9,7 +9,8 @@ const initialState = {
   facebook: '',
   instagram: '',
   whatsapp: '',
-  x: ''
+  x: '',
+  history: ''
 };
 
 const normaliseValue = (value) => (typeof value === 'string' ? value : '');
@@ -38,7 +39,8 @@ export default function ContactoClub() {
           facebook: normaliseValue(info.facebook),
           instagram: normaliseValue(info.instagram),
           whatsapp: normaliseValue(info.whatsapp),
-          x: normaliseValue(info.x)
+          x: normaliseValue(info.x),
+          history: normaliseValue(info.history)
         });
         const club = res.data?.club || {};
         setClubName(normaliseValue(club.nombreAmigable) || normaliseValue(club.nombre));
@@ -85,7 +87,8 @@ export default function ContactoClub() {
         facebook: normaliseValue(info.facebook),
         instagram: normaliseValue(info.instagram),
         whatsapp: normaliseValue(info.whatsapp),
-        x: normaliseValue(info.x)
+        x: normaliseValue(info.x),
+        history: normaliseValue(info.history)
       });
       const updatedClub = res.data?.club || {};
       setClubName((prev) => normaliseValue(updatedClub.nombreAmigable) || normaliseValue(updatedClub.nombre) || prev);
@@ -274,6 +277,25 @@ export default function ContactoClub() {
                         onChange={handleChange}
                         disabled={saving}
                       />
+                    </div>
+
+                    <div className="col-12">
+                      <label htmlFor="history" className="form-label">
+                        Historia del club
+                      </label>
+                      <textarea
+                        id="history"
+                        name="history"
+                        className="form-control"
+                        placeholder="Contá cómo nació y creció el club"
+                        value={form.history}
+                        onChange={handleChange}
+                        rows="6"
+                        disabled={saving}
+                      ></textarea>
+                      <div className="form-text">
+                        Este texto se mostrará en el recuadro de historia del pie de página.
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- add a persistent history field to club contact information so it is included in defaults and API responses
- allow administrators to edit the history text from the club contact page and broadcast updates to the frontend
- render the footer history bubble from the stored contact information while keeping existing contact links dynamic

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910622291ec83208b02abda1fc16cc9)