### PR TITLE
Sync footer contact info with delegate updates

### DIFF
--- a/frontend-auth/src/utils/clubContext.js
+++ b/frontend-auth/src/utils/clubContext.js
@@ -1,14 +1,69 @@
 export const CLUB_CONTEXT_EVENT = 'clubContextChanged';
 
+const CONTACT_INFO_STORAGE_KEY = 'clubContactInfo';
+const CONTACT_INFO_KEYS = Object.freeze([
+  'phone',
+  'email',
+  'address',
+  'mapUrl',
+  'facebook',
+  'instagram',
+  'whatsapp',
+  'x',
+  'history'
+]);
+
 const normaliseClubId = (clubId) => {
   if (typeof clubId !== 'string') return null;
   const trimmed = clubId.trim();
   return trimmed ? trimmed : null;
 };
 
+const normaliseContactInfoValue = (value) => (typeof value === 'string' ? value : '');
+
+const buildStoredContactInfo = (raw) =>
+  CONTACT_INFO_KEYS.reduce((acc, key) => {
+    acc[key] = normaliseContactInfoValue(raw?.[key]);
+    return acc;
+  }, {});
+
 export const getStoredClubId = () => {
   const stored = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('clubId') : null;
   return normaliseClubId(stored);
+};
+
+export const getStoredClubContactInfo = () => {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    const stored = sessionStorage.getItem(CONTACT_INFO_STORAGE_KEY);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return buildStoredContactInfo(parsed);
+  } catch {
+    return null;
+  }
+};
+
+export const setStoredClubContactInfo = (contactInfo) => {
+  if (typeof sessionStorage === 'undefined') return null;
+  if (!contactInfo || typeof contactInfo !== 'object') {
+    sessionStorage.removeItem(CONTACT_INFO_STORAGE_KEY);
+    return null;
+  }
+
+  const sanitised = CONTACT_INFO_KEYS.reduce((acc, key) => {
+    acc[key] = normaliseContactInfoValue(contactInfo[key]);
+    return acc;
+  }, {});
+
+  sessionStorage.setItem(CONTACT_INFO_STORAGE_KEY, JSON.stringify(sanitised));
+  return buildStoredContactInfo(sanitised);
+};
+
+export const clearStoredClubContactInfo = () => {
+  if (typeof sessionStorage === 'undefined') return;
+  sessionStorage.removeItem(CONTACT_INFO_STORAGE_KEY);
 };
 
 export const setStoredClubId = (clubId) => {
@@ -22,6 +77,7 @@ export const setStoredClubId = (clubId) => {
   }
 
   if (previous !== normalised) {
+    clearStoredClubContactInfo();
     window.dispatchEvent(
       new CustomEvent(CLUB_CONTEXT_EVENT, {
         detail: { clubId: normalised }


### PR DESCRIPTION
## Summary
- persist a normalised copy of each club's contact data in session storage so it can be reused across components
- hydrate the footer from the stored contact information, keep it in sync with delegate edits, and reset the view when the selected club changes

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b15e29188320954fda76e2079add)