### PR TITLE
Add club subscription enforcement and expose status to clients

### DIFF
--- a/backend-auth/controllers/authController.js
+++ b/backend-auth/controllers/authController.js
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 import enviarEmailConfirmacion from '../utils/enviarEmailConfirmacion.js';
 import jwt from 'jsonwebtoken';
 import { comparePasswordWithHash } from '../utils/passwordUtils.js';
+import { loadClubSubscription } from '../utils/subscriptionUtils.js';
 
 // Clave JWT unificada
 const JWT_SECRET = process.env.JWT_SECRET || 'secreto';
@@ -109,6 +110,12 @@ export const loginUsuario = async (req, res) => {
       return res.status(401).json({ mensaje: 'Contraseña incorrecta' });
     }
 
+    let clubSubscription = null;
+    if (usuario.club) {
+      const subscriptionResult = await loadClubSubscription(usuario.club, { persistDefaults: true });
+      clubSubscription = subscriptionResult?.subscriptionState ?? null;
+    }
+
     const token = jwt.sign(
       { id: usuario._id, rol: usuario.rol },
       JWT_SECRET,
@@ -123,8 +130,10 @@ export const loginUsuario = async (req, res) => {
         apellido: usuario.apellido,
         email: usuario.email,
         rol: usuario.rol,
-        foto: usuario.foto
-      }
+        foto: usuario.foto,
+        club: usuario.club ? usuario.club.toString() : null
+      },
+      clubSubscription
     });
   } catch (error) {
     console.error('Error en loginUsuario', error);

--- a/backend-auth/middlewares/authMiddleware.js
+++ b/backend-auth/middlewares/authMiddleware.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import User from '../models/User.js';
+import { loadClubSubscription } from '../utils/subscriptionUtils.js';
 
 export const protegerRuta = async (req, res, next) => {
   const authHeader = req.headers.authorization;
@@ -24,6 +25,52 @@ export const protegerRuta = async (req, res, next) => {
       rol: usuario.rol,
       club: usuario.club ? usuario.club.toString() : null
     };
+
+    req.club = null;
+
+    const rolNormalizado = typeof req.usuario.rol === 'string' ? req.usuario.rol.toLowerCase() : '';
+    const debeValidarSuscripcion = rolNormalizado && rolNormalizado !== 'admin' && req.usuario.club;
+
+    if (debeValidarSuscripcion) {
+      const resultadoSuscripcion = await loadClubSubscription(req.usuario.club, {
+        persistDefaults: true
+      });
+
+      if (!resultadoSuscripcion) {
+        return res.status(403).json({ mensaje: 'El club asociado al usuario no existe' });
+      }
+
+      const { club, subscriptionState } = resultadoSuscripcion;
+
+      req.club = {
+        id: club._id.toString(),
+        nombre: club.nombre,
+        subscription: subscriptionState
+      };
+
+      if (!subscriptionState?.isActive) {
+        const rawPath = `${req.baseUrl || ''}${req.path || ''}`;
+        const normalisePath = (value) => {
+          if (!value) return '';
+          return value.split('?')[0].replace(/\/+$/, '') || '/';
+        };
+
+        const requestPath = normalisePath(req.originalUrl) || normalisePath(rawPath);
+        const allowedInactivePaths = new Set(['/api/protegido/usuario']);
+        const isAllowed =
+          allowedInactivePaths.has(requestPath) ||
+          allowedInactivePaths.has(normalisePath(rawPath)) ||
+          allowedInactivePaths.has(normalisePath(req.path));
+
+        if (!isAllowed) {
+          return res.status(402).json({
+            mensaje:
+              'La suscripción del club está inactiva. Contactá a tu delegado para regularizar el pago.',
+            subscription: subscriptionState
+          });
+        }
+      }
+    }
     next();
   } catch (error) {
     return res.status(401).json({ mensaje: 'Token inválido' });

--- a/backend-auth/models/Club.js
+++ b/backend-auth/models/Club.js
@@ -1,5 +1,38 @@
 import mongoose from 'mongoose';
 
+const DEFAULT_TRIAL_DAYS = 30;
+
+const parsePositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
+const resolveTrialDays = () => parsePositiveInteger(process.env.CLUB_TRIAL_DAYS, DEFAULT_TRIAL_DAYS);
+
+const addDays = (date, days) => {
+  const base = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(base.getTime())) {
+    return new Date(Date.now() + days * 86400000);
+  }
+  return new Date(base.getTime() + days * 86400000);
+};
+
+const buildDefaultSubscriptionSnapshot = () => {
+  const now = new Date();
+  return {
+    status: 'trial',
+    trialStartedAt: now,
+    trialEndsAt: addDays(now, resolveTrialDays()),
+    currentPeriodEndsAt: null,
+    graceEndsAt: null,
+    lastPaymentAt: null,
+    notes: ''
+  };
+};
+
 const tituloSchema = new mongoose.Schema(
   {
     titulo: { type: String, required: true, trim: true },
@@ -27,6 +60,23 @@ const contactInfoSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const subscriptionSchema = new mongoose.Schema(
+  {
+    status: {
+      type: String,
+      enum: ['trial', 'active', 'grace', 'past_due', 'inactive'],
+      default: 'trial'
+    },
+    trialStartedAt: { type: Date },
+    trialEndsAt: { type: Date },
+    currentPeriodEndsAt: { type: Date },
+    graceEndsAt: { type: Date },
+    lastPaymentAt: { type: Date },
+    notes: { type: String, trim: true }
+  },
+  { _id: false }
+);
+
 const clubSchema = new mongoose.Schema(
   {
     nombre: { type: String, required: true, unique: true, trim: true },
@@ -35,12 +85,16 @@ const clubSchema = new mongoose.Schema(
     logo: { type: String, trim: true },
     titulos: { type: [tituloSchema], default: [] },
     contactInfo: { type: contactInfoSchema, default: () => ({}) },
+    subscription: { type: subscriptionSchema, default: buildDefaultSubscriptionSnapshot },
     creadoPor: { type: mongoose.Schema.Types.ObjectId, ref: 'User' }
   },
   { timestamps: true }
 );
 
 clubSchema.pre('save', function (next) {
+  if (typeof this.ensureSubscriptionDefaults === 'function') {
+    this.ensureSubscriptionDefaults();
+  }
   this.nombre = this.nombre.trim().toUpperCase();
   if (typeof this.nombreAmigable === 'string') {
     this.nombreAmigable = this.nombreAmigable.trim();
@@ -50,5 +104,129 @@ clubSchema.pre('save', function (next) {
   }
   next();
 });
+
+const normaliseDate = (value) => {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+clubSchema.methods.ensureSubscriptionDefaults = function ensureSubscriptionDefaults() {
+  if (!this.subscription || typeof this.subscription !== 'object') {
+    this.subscription = buildDefaultSubscriptionSnapshot();
+    return true;
+  }
+
+  let mutated = false;
+  if (!this.subscription.status) {
+    this.subscription.status = 'trial';
+    mutated = true;
+  }
+
+  if (!this.subscription.trialStartedAt) {
+    this.subscription.trialStartedAt = new Date();
+    mutated = true;
+  }
+
+  if (!this.subscription.trialEndsAt) {
+    const base = normaliseDate(this.subscription.trialStartedAt) || new Date();
+    this.subscription.trialEndsAt = addDays(base, resolveTrialDays());
+    mutated = true;
+  }
+
+  return mutated;
+};
+
+clubSchema.methods.getSubscriptionSnapshot = function getSubscriptionSnapshot() {
+  const raw = this.subscription && typeof this.subscription === 'object'
+    ? typeof this.subscription.toObject === 'function'
+      ? this.subscription.toObject()
+      : this.subscription
+    : {};
+  const snapshot = { ...buildDefaultSubscriptionSnapshot(), ...raw };
+  snapshot.status = (raw.status || snapshot.status || 'trial').toLowerCase();
+  snapshot.trialStartedAt = normaliseDate(snapshot.trialStartedAt);
+  snapshot.trialEndsAt = normaliseDate(snapshot.trialEndsAt);
+  snapshot.currentPeriodEndsAt = normaliseDate(snapshot.currentPeriodEndsAt);
+  snapshot.graceEndsAt = normaliseDate(snapshot.graceEndsAt);
+  snapshot.lastPaymentAt = normaliseDate(snapshot.lastPaymentAt);
+  return snapshot;
+};
+
+clubSchema.methods.getSubscriptionState = function getSubscriptionState(referenceDate = new Date()) {
+  const now = referenceDate instanceof Date ? referenceDate : new Date(referenceDate);
+  const nowTime = now.getTime();
+  const snapshot = this.getSubscriptionSnapshot();
+
+  const trialEndsAt = snapshot.trialEndsAt ? snapshot.trialEndsAt.getTime() : null;
+  const currentPeriodEndsAt = snapshot.currentPeriodEndsAt ? snapshot.currentPeriodEndsAt.getTime() : null;
+  const graceEndsAt = snapshot.graceEndsAt ? snapshot.graceEndsAt.getTime() : null;
+
+  let status = snapshot.status || 'trial';
+  let isActive = false;
+  let reason = 'inactive';
+
+  if (status === 'inactive') {
+    reason = 'inactive';
+  } else if (status === 'trial') {
+    if (!trialEndsAt || trialEndsAt >= nowTime) {
+      isActive = true;
+      reason = 'trial';
+    } else if (graceEndsAt && graceEndsAt >= nowTime) {
+      isActive = true;
+      status = 'grace';
+      reason = 'trial-grace';
+    } else {
+      reason = 'trial-expired';
+    }
+  } else if (status === 'active') {
+    if (!currentPeriodEndsAt || currentPeriodEndsAt >= nowTime) {
+      isActive = true;
+      reason = 'active';
+    } else if (graceEndsAt && graceEndsAt >= nowTime) {
+      isActive = true;
+      status = 'grace';
+      reason = 'grace';
+    } else {
+      reason = 'subscription-expired';
+    }
+  } else if (status === 'grace') {
+    if (graceEndsAt && graceEndsAt >= nowTime) {
+      isActive = true;
+      reason = 'grace';
+    } else {
+      reason = 'grace-expired';
+    }
+  } else if (status === 'past_due') {
+    if (graceEndsAt && graceEndsAt >= nowTime) {
+      isActive = true;
+      status = 'grace';
+      reason = 'past-due-grace';
+    } else {
+      reason = 'payment-required';
+    }
+  } else {
+    reason = 'inactive';
+  }
+
+  return {
+    ...snapshot,
+    status,
+    isActive,
+    reason,
+    trialExpired: Boolean(trialEndsAt && trialEndsAt < nowTime),
+    currentPeriodExpired: Boolean(currentPeriodEndsAt && currentPeriodEndsAt < nowTime),
+    graceExpired: Boolean(graceEndsAt && graceEndsAt < nowTime),
+    evaluatedAt: now
+  };
+};
+
+clubSchema.methods.isSubscriptionActive = function isSubscriptionActive(referenceDate = new Date()) {
+  const state = this.getSubscriptionState(referenceDate);
+  return Boolean(state?.isActive);
+};
 
 export default mongoose.model('Club', clubSchema);

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -32,6 +32,7 @@ import ExcelJS from 'exceljs';
 import pdfToJson from './utils/pdfToJson.js';
 import parseResultadosJson from './utils/parseResultadosJson.js';
 import { comparePasswordWithHash } from './utils/passwordUtils.js';
+import { loadClubSubscription } from './utils/subscriptionUtils.js';
 
 dotenv.config();
 
@@ -1518,6 +1519,12 @@ app.post('/api/auth/login', async (req, res) => {
       return res.status(400).json({ mensaje: 'Credenciales inválidas' });
     }
 
+    let clubSubscription = null;
+    if (usuario.club) {
+      const subscriptionResult = await loadClubSubscription(usuario.club, { persistDefaults: true });
+      clubSubscription = subscriptionResult?.subscriptionState ?? null;
+    }
+
     const sanitizedUser = (await ensureAdminHasNoAssociations(usuario)) || usuario;
 
     const tokenPayload = {
@@ -1535,7 +1542,8 @@ app.post('/api/auth/login', async (req, res) => {
         foto: sanitizedUser.foto || '',
         club: sanitizedUser.club ? sanitizedUser.club.toString() : null
       },
-      needsClubSelection
+      needsClubSelection,
+      clubSubscription
     });
   } catch (err) {
     console.error('Error en /api/auth/login', err);
@@ -1572,7 +1580,10 @@ app.get('/api/protegido/usuario', protegerRuta, async (req, res) => {
       .select('-password')
       .populate('patinadores')
       .populate({ path: 'club', populate: { path: 'federation' } });
-    res.json({ usuario });
+    res.json({
+      usuario,
+      clubSubscription: req.club?.subscription ?? null
+    });
   } catch {
     res.status(500).json({ mensaje: 'Error al obtener el usuario' });
   }

--- a/backend-auth/utils/subscriptionUtils.js
+++ b/backend-auth/utils/subscriptionUtils.js
@@ -1,0 +1,45 @@
+import Club from '../models/Club.js';
+
+const shouldPersistDefaults = (options = {}) => {
+  if (typeof options.persistDefaults === 'boolean') {
+    return options.persistDefaults;
+  }
+  if (typeof options.saveDefaults === 'boolean') {
+    return options.saveDefaults;
+  }
+  return true;
+};
+
+export const loadClubSubscription = async (clubId, options = {}) => {
+  if (!clubId) return null;
+
+  const club = await Club.findById(clubId).select('nombre subscription');
+  if (!club) return null;
+
+  const persistDefaults = shouldPersistDefaults(options);
+  let mutated = false;
+
+  if (typeof club.ensureSubscriptionDefaults === 'function') {
+    mutated = club.ensureSubscriptionDefaults();
+  }
+
+  if (mutated && persistDefaults) {
+    try {
+      await club.save();
+    } catch (error) {
+      console.warn('No se pudo guardar la configuración de suscripción por defecto del club.', error);
+    }
+  }
+
+  const subscriptionState =
+    typeof club.getSubscriptionState === 'function'
+      ? club.getSubscriptionState()
+      : { isActive: true, status: 'unknown', reason: 'missing-method' };
+
+  return {
+    club,
+    subscriptionState
+  };
+};
+
+export default loadClubSubscription;


### PR DESCRIPTION
## Summary
- add persistent subscription metadata and helpers to the Club model
- enforce club subscription checks for protected routes while allowing account retrieval when inactive
- surface club subscription details in login responses and user profile API, sharing loader utility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bb46c1f88320ba0c595901041f03)