### PR TITLE
Fix backend startup by removing duplicate subscription import

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -35,8 +35,6 @@ import { comparePasswordWithHash } from './utils/passwordUtils.js';
 
 import { loadClubSubscription, buildSubscriptionPlansResponse } from './utils/subscriptionUtils.js';
 
-import { loadClubSubscription } from './utils/subscriptionUtils.js';
-
 
 dotenv.config();
 


### PR DESCRIPTION
## Summary
- remove the duplicated subscriptionUtils import in the backend server entrypoint to avoid the startup syntax error

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917767b1a9c8320b1f658e262942214)