### PR TITLE
Make local club subscription bonified

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -988,7 +988,8 @@ const ensureLocalClub = async () => {
     club = await Club.create({
       nombre: LOCAL_CLUB_CANONICAL_NAME,
       nombreAmigable: LOCAL_CLUB_DISPLAY_NAME,
-      contactInfo: { ...DEFAULT_LOCAL_CONTACT_INFO }
+      contactInfo: { ...DEFAULT_LOCAL_CONTACT_INFO },
+      subscriptionBonified: true
     });
     return club;
   }
@@ -997,6 +998,11 @@ const ensureLocalClub = async () => {
 
   if (!club.nombreAmigable) {
     club.nombreAmigable = LOCAL_CLUB_DISPLAY_NAME;
+    shouldSave = true;
+  }
+
+  if (!club.subscriptionBonified) {
+    club.subscriptionBonified = true;
     shouldSave = true;
   }
 


### PR DESCRIPTION
## Summary
- add a new Club.subscriptionBonified flag and use it to keep the local club permanently active
- ensure getSubscriptionState reflects the bonified state (always active with free pricing)
- mark the local club as bonified when creating or loading the default record

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919e2caae148320b56ec79da896a4f2)