### PR TITLE
Handle Mercado Pago sandbox token fallback

### DIFF
--- a/backend-auth/utils/mercadoPago.js
+++ b/backend-auth/utils/mercadoPago.js
@@ -114,13 +114,20 @@ const resolveAccessToken = () => {
     return { accessToken: sandboxToken, useSandbox: true };
   }
 
-  if (!accessToken) {
-    throw new MercadoPagoConfigurationError(
-      'Mercado Pago no está configurado. Configurá MERCADOPAGO_ACCESS_TOKEN o habilitá MERCADOPAGO_USE_SANDBOX con MERCADOPAGO_ACCESS_TOKEN_SANDBOX.'
-    );
+  if (accessToken) {
+    return { accessToken, useSandbox: false };
   }
 
-  return { accessToken, useSandbox: false };
+  if (sandboxToken) {
+    console.warn(
+      'MERCADOPAGO_USE_SANDBOX no está activado, pero se encontró MERCADOPAGO_ACCESS_TOKEN_SANDBOX. Se usará modo sandbox por defecto.'
+    );
+    return { accessToken: sandboxToken, useSandbox: true };
+  }
+
+  throw new MercadoPagoConfigurationError(
+    'Mercado Pago no está configurado. Configurá MERCADOPAGO_ACCESS_TOKEN o habilitá MERCADOPAGO_USE_SANDBOX con MERCADOPAGO_ACCESS_TOKEN_SANDBOX.'
+  );
 };
 
 const createMercadoPagoPreference = async ({ plan, clubId, conversion, user }) => {


### PR DESCRIPTION
## Summary
- allow Mercado Pago configuration to automatically use the sandbox token when no production token is set
- add a warning log to clarify when sandbox mode is enabled implicitly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be9d1e08c8320b4cb502c928cd60d)