### PR TITLE
Change heading color to red

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -9,6 +9,7 @@
   --bg-gradient-top: rgba(20, 86, 150, 0.12);
   --bg-gradient-bottom: #ffffff;
   --text-color: #0f0d0e;
+  --title-color: #ff0000;
   --muted-text: rgba(15, 13, 14, 0.65);
   --card-bg: rgba(255, 255, 255, 0.95);
   --card-border: rgba(20, 86, 150, 0.12);
@@ -39,7 +40,7 @@ h3 {
   font-family: 'Barlow', 'Montserrat', sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--primary-color);
+  color: var(--title-color);
 }
 
 p {


### PR DESCRIPTION
## Summary
- introduce a dedicated title color variable set to red
- update global heading styles to use the new red title color

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e8cae7074832082627c0b380917d5)