### PR TITLE
Restore heading color

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -9,7 +9,7 @@
   --bg-gradient-top: rgba(20, 86, 150, 0.12);
   --bg-gradient-bottom: #ffffff;
   --text-color: #0f0d0e;
-  --title-color: #ff0000;
+  --title-color: #145696;
   --muted-text: rgba(15, 13, 14, 0.65);
   --card-bg: rgba(255, 255, 255, 0.95);
   --card-border: rgba(20, 86, 150, 0.12);


### PR DESCRIPTION
## Summary
- reset the title color variable to the primary palette color instead of the temporary red test

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692063c30380832091e3ba5b276c9a1c)