### PR TITLE
Load root env when configuring Mercado Pago

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -53,12 +53,17 @@ import {
   MercadoPagoConfigurationError
 } from './utils/mercadoPago.js';
 
-
-dotenv.config();
-
-// --------- Paths / TZ ---------
+// --------- Paths / ENV ---------
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+dotenv.config();
+const additionalEnv = path.resolve(__dirname, '..', '.env');
+if (fs.existsSync(additionalEnv)) {
+  dotenv.config({ path: additionalEnv, override: false });
+}
+
+// --------- Paths / TZ ---------
 process.env.TZ = 'America/Argentina/Buenos_Aires';
 
 // --------- Uploads dir ---------


### PR DESCRIPTION
## Summary
- load dotenv from the backend folder and fallback to a repo-level .env file
- ensure Mercado Pago credentials defined outside backend-auth are picked up during checkout setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ca8f72188320a6d8c466e28edfb0)