### PR TITLE
Handle expired trials by blocking access

### DIFF
--- a/backend-auth/middlewares/authMiddleware.js
+++ b/backend-auth/middlewares/authMiddleware.js
@@ -2,6 +2,13 @@ import jwt from 'jsonwebtoken';
 import User from '../models/User.js';
 import { loadClubSubscription } from '../utils/subscriptionUtils.js';
 
+const formatDateForLocale = (value) => {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString('es-AR', { day: '2-digit', month: 'long', year: 'numeric' });
+};
+
 export const protegerRuta = async (req, res, next) => {
   const authHeader = req.headers.authorization;
 
@@ -63,9 +70,18 @@ export const protegerRuta = async (req, res, next) => {
           allowedInactivePaths.has(normalisePath(req.path));
 
         if (!isAllowed) {
+          const trialExpiredMessage = subscriptionState.trialExpired
+            ? `El período de prueba venció el ${formatDateForLocale(
+                subscriptionState.trialEndsAt
+              )}. Activá la suscripción para seguir usando la plataforma.`
+            : '';
+
+          const inactiveMessage =
+            trialExpiredMessage ||
+            'La suscripción del club está inactiva. Contactá a tu delegado para regularizar el pago.';
+
           return res.status(402).json({
-            mensaje:
-              'La suscripción del club está inactiva. Contactá a tu delegado para regularizar el pago.',
+            mensaje: inactiveMessage,
             subscription: subscriptionState
           });
         }

--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -167,6 +167,23 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    if (error.response?.status === 402) {
+      const message =
+        error.response?.data?.mensaje ||
+        'La suscripción del club está vencida. Regularizá el pago para continuar usando la plataforma.';
+      try {
+        sessionStorage.setItem('subscriptionBlockedMessage', message);
+      } catch (storageErr) {
+        console.warn('No se pudo guardar el aviso de suscripción inactiva', storageErr);
+      }
+
+      if (typeof window !== 'undefined') {
+        window.location.href = '/suscripciones';
+      }
+
+      return Promise.reject(error);
+    }
+
     if (baseUrlCandidates.length > 1 && shouldRetryWithFallback(error)) {
       const currentIndex = typeof error.config.__candidateIndex === 'number'
         ? error.config.__candidateIndex


### PR DESCRIPTION
## Summary
- return clearer messaging when a club intenta operar con la suscripción vencida, incluyendo el fin del período de prueba
- redirigir desde el frontend a la vista de suscripciones y mostrar el aviso cuando el backend responde con estado 402
- reflejar en la pantalla de suscripciones cuando el período de prueba ya venció

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ec358dcc8320bcb20e30d747c5a7)