### PR TITLE
Change title color to yellow

### DIFF
--- a/frontend-auth/src/styles.css
+++ b/frontend-auth/src/styles.css
@@ -9,7 +9,7 @@
   --bg-gradient-top: rgba(20, 86, 150, 0.12);
   --bg-gradient-bottom: #ffffff;
   --text-color: #0f0d0e;
-  --title-color: #145696;
+  --title-color: #ffd700;
   --muted-text: rgba(15, 13, 14, 0.65);
   --card-bg: rgba(255, 255, 255, 0.95);
   --card-border: rgba(20, 86, 150, 0.12);


### PR DESCRIPTION
## Summary
- update the theme title color variable to display headings in yellow

## Testing
- npm test *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f65083488320a415c65287198898)