### PR TITLE
Improve API base URL fallback handling

### DIFF
--- a/frontend-auth/.env.example
+++ b/frontend-auth/.env.example
@@ -1,2 +1,3 @@
+# Comma-separated API base URLs to try in order
 VITE_API_URL=https://patincarrera.net/api
 VITE_BACKEND_PORT=5000

--- a/frontend-auth/.env.production
+++ b/frontend-auth/.env.production
@@ -1,1 +1,2 @@
+# Comma-separated API base URLs to try in order
 VITE_API_BASE=https://patincarrera.net/api


### PR DESCRIPTION
## Summary
- normalize API base URLs from comma-separated environment values and reuse them for Axios fallbacks
- add browser-safe runtime location handling with a final `/api/` candidate to avoid hard failures when a host is down
- document the API base configuration in the environment templates

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bbe69bdc83209de956348effbd5e)