### PR TITLE
Fix API base URL fallback handling

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -101,10 +101,8 @@ let activeBaseUrlIndex = 0;
 const getBaseUrlForIndex = (index) =>
   baseUrlCandidates[index] || baseUrlCandidates[0] || ensureApiSuffix('/');
 
-const resolvedEnvBaseUrl = envBaseUrls[0] || ensureApiSuffix(import.meta.env.VITE_API_URL?.trim());
-
 const api = axios.create({
-  baseURL: resolvedEnvBaseUrl || getBaseUrlForIndex(activeBaseUrlIndex),
+  baseURL: getBaseUrlForIndex(activeBaseUrlIndex),
   withCredentials: true
 });
 
@@ -112,7 +110,7 @@ const api = axios.create({
 // keeping the snippet required by downstream consumers that rely on the raw
 // `VITE_API_URL` configuration. When the environment variable isn't present we
 // fall back to the dynamically resolved backend base.
-api.defaults.baseURL = resolvedEnvBaseUrl || getBaseUrlForIndex(activeBaseUrlIndex);
+api.defaults.baseURL = getBaseUrlForIndex(activeBaseUrlIndex);
 
 
 api.interceptors.request.use((config) => {
@@ -135,7 +133,7 @@ api.interceptors.request.use((config) => {
     config.__fallbackAttempt = 0;
   }
 
-  config.baseURL = resolvedEnvBaseUrl || getBaseUrlForIndex(config.__candidateIndex);
+  config.baseURL = getBaseUrlForIndex(config.__candidateIndex);
 
   // Ensure request URLs remain relative so the Axios base URL is respected.
   if (config.baseURL && config.url?.startsWith('/')) {
@@ -170,7 +168,7 @@ api.interceptors.response.use(
       const currentIndex = response.config.__candidateIndex;
       if (currentIndex !== activeBaseUrlIndex) {
         activeBaseUrlIndex = currentIndex;
-        api.defaults.baseURL = resolvedEnvBaseUrl || getBaseUrlForIndex(activeBaseUrlIndex);
+        api.defaults.baseURL = getBaseUrlForIndex(activeBaseUrlIndex);
       }
     }
     return response;
@@ -215,10 +213,10 @@ api.interceptors.response.use(
           (typeof error.config.__fallbackAttempt === 'number'
             ? error.config.__fallbackAttempt
             : 0) + 1;
-        error.config.baseURL = resolvedEnvBaseUrl || nextBaseUrl;
+        error.config.baseURL = nextBaseUrl;
 
         activeBaseUrlIndex = nextIndex;
-        api.defaults.baseURL = resolvedEnvBaseUrl || nextBaseUrl;
+        api.defaults.baseURL = nextBaseUrl;
 
         return api(error.config);
       }


### PR DESCRIPTION
## Summary
- let the Axios client fully switch to alternate base URL candidates when the primary endpoint fails
- update fallback retry logic to keep the active base URL in sync with the working candidate

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c1bbb1d88320babe3576ea3dd33a)