### PR TITLE
Improve API base URL fallbacks

### DIFF
--- a/frontend-auth/.env.example
+++ b/frontend-auth/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=https://patincarrera.net/api
+VITE_API_BASE=/api
 VITE_BACKEND_PORT=5000

--- a/frontend-auth/.env.production
+++ b/frontend-auth/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE=https://patincarrera.net/api
+VITE_API_BASE=/api


### PR DESCRIPTION
## Summary
- prefer the current origin and protocol variants when building API base URLs so the frontend can recover from hostname/CDN issues
- expand Axios fallback candidates with swapped protocol options to keep requests working if HTTPS or HTTP fails
- update default environment files to use the same-origin `/api` prefix

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692760e2e5e48320807b87c0bcaad2d3)