### PR TITLE
Fix API host handling to avoid CORS and 502 errors

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -55,7 +55,11 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    cd ..
    ```
 
-## 4. Nginx
+   The `.env.example` file now points `VITE_API_BASE` to `/api` so the frontend
+   always talks to the backend through the same origin handled by Nginx,
+   avoiding CORS issues between `patincarrera.net` and `www.patincarrera.net`.
+
+ ## 4. Nginx
 1. Copy the provided configuration:
    ```bash
    sudo cp deployment/nginx.conf /etc/nginx/sites-available/patincarrera
@@ -70,8 +74,10 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    sudo systemctl restart nginx
    ```
 2. Point the domain DNS records for `patincarrera.net` and `www.patincarrera.net` to the server IP `72.60.62.242`.
-3. Once HTTPS certificates are issued you can uncomment the redirect in the
-   provided config so every visitor is forced to use `https://`.
+3. The provided configuration now redirects `www.patincarrera.net` to the apex
+   domain to avoid cross-origin calls between both hosts. Once HTTPS
+   certificates are issued you can uncomment the redirect in the main server
+   block so every visitor is forced to use `https://`.
 
 ## 5. Optional HTTPS
 Use [Certbot](https://certbot.eff.org/) to obtain a Let's Encrypt certificate:

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,7 +1,17 @@
 server {
     listen 80;
     listen [::]:80;
-    server_name patincarrera.net www.patincarrera.net;
+    server_name www.patincarrera.net;
+
+    # Always force visitors to use the apex domain to avoid cross-origin
+    # requests between patincarrera.net and www.patincarrera.net.
+    return 301 https://patincarrera.net$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name patincarrera.net;
 
     # Serve the Vite build generated with `npm run build`
     root /var/www/patincarrera/frontend/dist;

--- a/frontend-auth/.env.example
+++ b/frontend-auth/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=https://patincarrera.net/api
+VITE_API_BASE=/api
 VITE_BACKEND_PORT=5000

--- a/frontend-auth/.env.production
+++ b/frontend-auth/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE=https://patincarrera.net/api
+VITE_API_BASE=/api

--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -65,14 +65,11 @@ const buildApiBaseUrlCandidates = () => {
     candidates.push(ensureApiSuffix(`${protocol}//${hostname}:${port}`));
   }
 
+  // Prefer staying on the current origin to avoid accidental cross-origin
+  // fallbacks (e.g. patincarrera.net -> www.patincarrera.net) that would
+  // trigger CORS errors in production. Additional hosts can be injected via
+  // `VITE_API_BASE`/`VITE_API_URL` when explicitly required.
   candidates.push(ensureApiSuffix(origin));
-
-  if (!hostname.startsWith('www.')) {
-    candidates.push(ensureApiSuffix(`${protocol}//www.${hostname}`));
-  } else {
-    const apexHost = hostname.replace(/^www\./, '');
-    candidates.push(ensureApiSuffix(`${protocol}//${apexHost}`));
-  }
 
   return unique(candidates);
 };


### PR DESCRIPTION
## Summary
- redirect www traffic to the apex domain in Nginx while keeping the API proxy and upload handling intact
- default the frontend API base to the same-origin `/api` path and remove automatic cross-host fallbacks that triggered CORS
- document the updated environment defaults and canonical host redirection in the deployment guide

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927abb19e2c8320b14783e9e48e4691)