### PR TITLE
Handle club identifiers provided as objects

### DIFF
--- a/frontend-auth/src/utils/clubContext.js
+++ b/frontend-auth/src/utils/clubContext.js
@@ -13,7 +13,19 @@ const CONTACT_INFO_KEYS = Object.freeze([
   'history'
 ]);
 
+const extractIdFromObject = (value) => {
+  if (!value || typeof value !== 'object') return null;
+  if (typeof value._id === 'string') return value._id;
+  if (typeof value.id === 'string') return value.id;
+  return null;
+};
+
 const normaliseClubId = (clubId) => {
+  if (clubId && typeof clubId === 'object') {
+    const extracted = extractIdFromObject(clubId);
+    if (extracted) return extracted.trim();
+  }
+
   if (typeof clubId !== 'string') return null;
   const trimmed = clubId.trim();
   return trimmed ? trimmed : null;


### PR DESCRIPTION
## Summary
- normalise stored club identifiers even when login responses provide embedded objects
- keep club selection change events and stored contact info in sync after accepting new identifier shapes

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0ffb0e248320b3f564f30786b086)