### PR TITLE
Improve Mercado Pago token resolution

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -21,6 +21,10 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    cd backend-auth
    cp .env.example .env
    # edit .env with real values (Mongo URI, JWT secret, email creds, etc.)
+   # Si vas a habilitar cobros con Mercado Pago asegurate de definir
+   # MERCADOPAGO_ACCESS_TOKEN. El backend también acepta los alias
+   # MERCADO_PAGO_ACCESS_TOKEN o MP_ACCESS_TOKEN para mayor compatibilidad
+   # con distintos paneles de hosting.
    # UPLOADS_DIR defaults to backend-auth/uploads. If you have legacy
    # assets in another directory you can list them in
    # UPLOADS_FALLBACK_DIRS=/ruta/vieja/uploads

--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -50,6 +50,7 @@ import { convertUsdToArsAtBlueRate } from './utils/currencyUtils.js';
 import {
   createMercadoPagoPreapproval,
   fetchPreapprovalDetails,
+  isMercadoPagoConfigured,
   parseExternalReference
 } from './utils/mercadoPagoUtils.js';
 
@@ -285,8 +286,6 @@ const resolveMercadoPagoWebhookUrl = () => {
     process.env.MERCADOPAGO_WEBHOOK_URL || process.env.MP_WEBHOOK_URL || `${BACKEND_URL}/api/mercadopago/webhook`;
   return configured.replace(/\s+/g, '');
 };
-
-const isMercadoPagoConfigured = () => Boolean(process.env.MERCADOPAGO_ACCESS_TOKEN?.trim());
 
 const allowedOrigins = Array.from(new Set([...DEFAULT_ALLOWED_ORIGINS, FRONTEND_URL, FRONTEND_URL_WWW]))
   .filter(Boolean);

--- a/backend-auth/utils/mercadoPagoUtils.js
+++ b/backend-auth/utils/mercadoPagoUtils.js
@@ -1,11 +1,27 @@
 import { MercadoPagoConfig, Preapproval } from 'mercadopago';
 
 const resolveAccessToken = () => {
-  const token = process.env.MERCADOPAGO_ACCESS_TOKEN?.trim();
+  const candidates = [
+    process.env.MERCADOPAGO_ACCESS_TOKEN,
+    process.env.MERCADO_PAGO_ACCESS_TOKEN,
+    process.env.MP_ACCESS_TOKEN
+  ];
+
+  const token = candidates.find((value) => typeof value === 'string' && value.trim());
   if (!token) {
-    throw new Error('Configurar MERCADOPAGO_ACCESS_TOKEN para habilitar los cobros con Mercado Pago.');
+    throw new Error(
+      'Configurar MERCADOPAGO_ACCESS_TOKEN (o MERCADO_PAGO_ACCESS_TOKEN / MP_ACCESS_TOKEN) para habilitar los cobros con Mercado Pago.'
+    );
   }
-  return token;
+  return token.trim();
+};
+
+const isMercadoPagoConfigured = () => {
+  try {
+    return Boolean(resolveAccessToken());
+  } catch (err) {
+    return false;
+  }
 };
 
 const buildMercadoPagoClient = () => {
@@ -79,4 +95,9 @@ const parseExternalReference = (value) => {
   };
 };
 
-export { createMercadoPagoPreapproval, fetchPreapprovalDetails, parseExternalReference };
+export {
+  createMercadoPagoPreapproval,
+  fetchPreapprovalDetails,
+  isMercadoPagoConfigured,
+  parseExternalReference
+};


### PR DESCRIPTION
## Summary
- allow Mercado Pago configuration to read alternate access token env vars
- surface configuration guidance for Mercado Pago tokens in deployment docs

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e467f40048320b264268787f1818a)