### PR TITLE
Add alternate host fallback for API calls

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -71,6 +71,16 @@ const buildApiBaseUrlCandidates = () => {
   // `VITE_API_BASE`/`VITE_API_URL` when explicitly required.
   candidates.push(ensureApiSuffix(origin));
 
+  // If the primary origin is temporarily unavailable (e.g. DNS propagation,
+  // upstream 502) try the alternate host with/without the `www.` prefix before
+  // giving up. This keeps the app usable during brief outages handled by the
+  // CDN or while the apex domain is being updated.
+  const hasWwwPrefix = hostname.startsWith('www.');
+  const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
+  if (alternateHost && alternateHost !== hostname) {
+    candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}`));
+  }
+
   return unique(candidates);
 };
 


### PR DESCRIPTION
## Summary
- add fallback API host candidate using the opposite www/non-www variant when primary origin fails
- keep axios base URL list resilient to temporary outages while preserving existing preferences

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f95635df08320870d686d6dfc1b48)