### PR TITLE
Improve frontend fallbacks for public data outages

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -89,6 +89,7 @@ export default function Footer() {
     } catch (err) {
       if (!mountedRef.current) return;
       console.error('Error al obtener la información de contacto del club', err);
+      applyContactInfo(DEFAULT_CONTACT_INFO);
     }
   }, [applyContactInfo]);
 

--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -49,7 +49,9 @@ export default function Navbar() {
   const [unread, setUnread] = useState(0);
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
   const [clubLogo, setClubLogo] = useState(normalisedClubLogo || '');
-  const [appDefaultLogo, setAppDefaultLogo] = useState(normalisedAppDefaultLogo || '');
+  const [appDefaultLogo, setAppDefaultLogo] = useState(
+    normalisedAppDefaultLogo || defaultBrandLogo
+  );
   const [clubName, setClubName] = useState(storedClubName);
   const [clubSubscriptionInfo, setClubSubscriptionInfo] = useState(null);
   const brandAlt = clubName ? `Logo de ${clubName}` : 'Logo Patín Carrera';
@@ -132,16 +134,17 @@ export default function Navbar() {
         const res = await api.get('/public/app-config');
         if (!active) return;
         const resolvedLogo = getImageUrl(res.data?.defaultBrandLogo);
-        if (resolvedLogo) {
-          setAppDefaultLogo(resolvedLogo);
-          sessionStorage.setItem('appDefaultLogo', resolvedLogo);
-        } else {
-          setAppDefaultLogo('');
-          sessionStorage.removeItem('appDefaultLogo');
-        }
+        const nextLogo = resolvedLogo || defaultBrandLogo;
+        setAppDefaultLogo(nextLogo);
+        sessionStorage.setItem('appDefaultLogo', nextLogo);
       } catch (err) {
         if (!active) return;
         console.error('Error al obtener la configuración de la aplicación', err);
+        setAppDefaultLogo((prev) => {
+          if (prev) return prev;
+          sessionStorage.setItem('appDefaultLogo', defaultBrandLogo);
+          return defaultBrandLogo;
+        });
       }
     };
 
@@ -150,13 +153,9 @@ export default function Navbar() {
     const handleAppConfigUpdate = (event) => {
       if (!event || typeof event !== 'object') return;
       const updatedLogo = getImageUrl(event.detail?.defaultBrandLogo);
-      if (updatedLogo) {
-        setAppDefaultLogo(updatedLogo);
-        sessionStorage.setItem('appDefaultLogo', updatedLogo);
-      } else {
-        setAppDefaultLogo('');
-        sessionStorage.removeItem('appDefaultLogo');
-      }
+      const nextLogo = updatedLogo || defaultBrandLogo;
+      setAppDefaultLogo(nextLogo);
+      sessionStorage.setItem('appDefaultLogo', nextLogo);
     };
 
     window.addEventListener('appConfigUpdated', handleAppConfigUpdate);


### PR DESCRIPTION
## Summary
- ensure the navbar keeps a default logo when fetching the public app configuration fails or returns empty data
- persist default branding updates from app-config events using the built-in asset as a fallback
- restore default club contact information when the public contact endpoint is unavailable

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69301a21ad208320a9a4b65eb6ffa2ea)