### PR TITLE
Update Mercado Pago utility implementation

### DIFF
--- a/backend-auth/utils/mercadoPagoUtils.js
+++ b/backend-auth/utils/mercadoPagoUtils.js
@@ -1,87 +1,95 @@
-import mercadopago from 'mercadopago';
+import { MercadoPagoConfig, PreApproval } from 'mercadopago';
 
-const { MercadoPagoConfig, PreApproval } = mercadopago;
+const accessToken = process.env.MERCADOPAGO_ACCESS_TOKEN || null;
 
-const resolveAccessToken = () => {
-  const candidates = [
-    process.env.MERCADOPAGO_ACCESS_TOKEN,
-    process.env.MERCADO_PAGO_ACCESS_TOKEN,
-    process.env.MP_ACCESS_TOKEN
-  ];
+/**
+ * Devuelve true si Mercado Pago está correctamente configurado
+ * (es decir, si hay ACCESS_TOKEN definido).
+ */
+const isMercadoPagoConfigured = () => Boolean(accessToken);
 
-  const token = candidates.find((value) => typeof value === 'string' && value.trim());
-  if (!token) {
+// Cliente de MP y cliente de PreApproval (suscripciones) solo si hay token
+const mpClient = accessToken
+  ? new MercadoPagoConfig({
+      accessToken,
+      options: {
+        timeout: 5000
+      }
+    })
+  : null;
+
+const preApprovalClient = mpClient ? new PreApproval(mpClient) : null;
+
+/**
+ * Crea una suscripción (PreApproval) en Mercado Pago.
+ * 
+ * params:
+ * - payerEmail: email del pagador
+ * - backUrl: URL a la que vuelve el usuario después de aprobar
+ * - reason: descripción/motivo de la suscripción
+ * - autoRecurring: objeto con frecuencia, monto, moneda, etc.
+ *   Ejemplo:
+ *   {
+ *     frequency: 1,
+ *     frequency_type: 'months',
+ *     transaction_amount: 10,
+ *     currency_id: 'ARS'
+ *   }
+ * - externalReference: string tipo "club:ID|plan:ID|user:ID"
+ */
+const createMercadoPagoPreapproval = async ({
+  payerEmail,
+  backUrl,
+  reason,
+  autoRecurring,
+  externalReference
+}) => {
+  if (!preApprovalClient) {
     throw new Error(
-      'Configurar MERCADOPAGO_ACCESS_TOKEN (o MERCADO_PAGO_ACCESS_TOKEN / MP_ACCESS_TOKEN) para habilitar los cobros con Mercado Pago.'
+      'Mercado Pago no está configurado. Falta MERCADOPAGO_ACCESS_TOKEN.'
     );
   }
-  return token.trim();
-};
 
-const isMercadoPagoConfigured = () => {
-  try {
-    return Boolean(resolveAccessToken());
-  } catch (err) {
-    return false;
-  }
-};
-
-const buildMercadoPagoClient = () => {
-  const integratorId = process.env.MERCADOPAGO_INTEGRATOR_ID?.trim();
-  return new MercadoPagoConfig({
-    accessToken: resolveAccessToken(),
-    options: {
-      ...(integratorId ? { integratorId } : {}),
-      timeout: 5000
-    }
-  });
-};
-
-const preapprovalClient = () => new PreApproval(buildMercadoPagoClient());
-
-const createMercadoPagoPreapproval = async ({
-  reason,
-  externalReference,
-  payerEmail,
-  transactionAmount,
-  currency = 'ARS',
-  backUrl,
-  notificationUrl
-}) => {
-  const client = preapprovalClient();
-  const payload = {
+  const body = {
+    payer_email: payerEmail,
+    back_url: backUrl,
     reason,
     external_reference: externalReference,
-    payer_email: payerEmail,
-    auto_recurring: {
-      frequency: 1,
-      frequency_type: 'months',
-      transaction_amount: transactionAmount,
-      currency_id: currency
-    },
-    back_url: backUrl,
-    notification_url: notificationUrl,
-    status: 'pending'
+    auto_recurring: autoRecurring
   };
 
-  const response = await client.create({ body: payload });
-  return {
-    id: response?.id ?? null,
-    initPoint: response?.init_point || response?.sandbox_init_point || null,
-    nextPaymentDate: response?.auto_recurring?.next_payment_date ?? null,
-    status: response?.status ?? null
-  };
+  const response = await preApprovalClient.create({ body });
+  return response;
 };
 
+/**
+ * Obtiene los detalles de una suscripción (PreApproval) por ID.
+ */
 const fetchPreapprovalDetails = async (preapprovalId) => {
-  if (!preapprovalId) return null;
-  const client = preapprovalClient();
-  const details = await client.get({ id: preapprovalId });
-  return details || null;
+  if (!preApprovalClient) {
+    throw new Error(
+      'Mercado Pago no está configurado. Falta MERCADOPAGO_ACCESS_TOKEN.'
+    );
+  }
+
+  if (!preapprovalId) {
+    throw new Error('preapprovalId es requerido para consultar la suscripción.');
+  }
+
+  const response = await preApprovalClient.get({ preapprovalId });
+  return response;
 };
 
+/**
+ * Parsea el external_reference que mandás a MP.
+ * Formato esperado: "club:ID_CLUB|plan:ID_PLAN|user:ID_USER"
+ * 
+ * Devuelve:
+ * { clubId, planId, userId } o null si falta club o plan.
+ */
 const parseExternalReference = (value) => {
   if (!value || typeof value !== 'string') return null;
+
   const parts = value.split('|').map((part) => part.trim());
   const meta = {};
 
@@ -93,6 +101,7 @@ const parseExternalReference = (value) => {
   }
 
   if (!meta.club || !meta.plan) return null;
+
   return {
     clubId: meta.club,
     planId: meta.plan,


### PR DESCRIPTION
## Summary
- replace Mercado Pago utility with new token handling and client setup
- update preapproval creation and retrieval functions to use new configuration
- keep external reference parsing helper aligned with new API usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b5ffecb4832093ba69bf61e63355)