### PR TITLE
Fix Mercado Pago subscription checkout configuration

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -2068,6 +2068,8 @@ app.post(
             payerEmail: user.email,
             transactionAmount: conversion.arsAmount,
             currency: 'ARS',
+            frequency: 1,
+            frequencyType: 'months',
             backUrl,
             notificationUrl: webhookUrl
           });


### PR DESCRIPTION
## Summary
- normalize Mercado Pago access tokens, accepting common environment variable aliases
- build Mercado Pago preapproval requests with recurring payment parameters and webhook URL

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b6fa2828832083f18c1c4943f4b7)