### PR TITLE
Add checkout route alias for subscription payments

### DIFF
--- a/frontend-auth/src/App.jsx
+++ b/frontend-auth/src/App.jsx
@@ -50,6 +50,11 @@ function AppRoutes() {
           <Route path="/" element={<Auth />} />
           <Route path="/home" element={<Home />} />
           <Route
+            path="/checkout"
+            element={<ProtectedRoute roles={['Delegado']}><Suscripciones /></ProtectedRoute>}
+          />
+          <Route path="/checkuot" element={<Navigate to="/checkout" replace />} />
+          <Route
             path="/suscripciones"
             element={<ProtectedRoute roles={['Delegado']}><Suscripciones /></ProtectedRoute>}
           />


### PR DESCRIPTION
## Summary
- add a protected /checkout path for the subscription flow and redirect the misspelled /checkuot path to it

## Testing
- npm run lint (fails: npm is not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346ea75b4c8320b0c07c0bbdcb6445)