### PR TITLE
Improve Mercado Pago checkout error response

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -2075,9 +2075,9 @@ app.post(
           });
         } catch (error) {
           console.error('No se pudo crear la preaprobación en Mercado Pago', error);
-          return res.status(502).json({
+          return res.status(503).json({
             mensaje:
-              'Mercado Pago no respondió correctamente. Verificá la configuración e intentá nuevamente en unos momentos.'
+              'No pudimos contactar a Mercado Pago para generar el cobro. Revisá las credenciales configuradas o intentá nuevamente en unos minutos.'
           });
         }
 


### PR DESCRIPTION
## Summary
- handle Mercado Pago preapproval creation failures with a clearer 503 response
- avoid exposing a generic 502 when the payment provider cannot be reached during subscription checkout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69354c7e1d5883208e15e3fa55c309b1)