### PR TITLE
Handle Mercado Pago availability for subscriptions

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1991,6 +1991,14 @@ app.post('/api/payments/methods', protegerRuta, permitirRol('Delegado', 'Admin')
   }
 });
 
+app.get('/api/subscriptions/status', protegerRuta, permitirRol('Delegado', 'Admin'), (req, res) => {
+  const status = getMercadoPagoConfigStatus();
+  res.json({
+    mercadoPagoAvailable: status.isConfigured,
+    mercadoPagoTimeoutMs: status.sdkTimeoutMs
+  });
+});
+
 app.post(
   '/api/subscriptions/checkout',
   protegerRuta,


### PR DESCRIPTION
## Summary
- add a subscription status endpoint that reports Mercado Pago availability
- check payment availability on the subscriptions page and disable Mercado Pago when unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9d86d3ac8320a1226f810b36889c)