### PR TITLE
Fix sanitization of club contact info

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -1181,16 +1181,17 @@ const normaliseContactUrlValue = (value) => {
 };
 
 const sanitiseContactInfoInput = (payload = {}) => {
-  const sanitized = {};
+  const sanitized = createEmptyContactInfo();
+
   for (const key of CONTACT_INFO_KEYS) {
     const raw = payload?.[key];
     const value = CONTACT_INFO_URL_KEYS.has(key)
       ? normaliseContactUrlValue(raw)
       : normaliseContactString(raw);
-    if (value) {
-      sanitized[key] = value;
-    }
+
+    sanitized[key] = value;
   }
+
   return sanitized;
 };
 


### PR DESCRIPTION
## Summary
- preserve all club contact info fields when sanitizing updates
- ensure saved contact details include empty strings instead of dropping keys

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f04ce6e108320b0526cdb15700d56)