### PR TITLE
Limit news detail image dimensions

### DIFF
--- a/frontend-auth/src/pages/VerNoticia.jsx
+++ b/frontend-auth/src/pages/VerNoticia.jsx
@@ -50,7 +50,8 @@ export default function VerNoticia() {
         <img
           src={noticia.imagen}
           alt="imagen noticia"
-          className="img-fluid mb-3"
+          className="img-fluid mb-3 d-block mx-auto"
+          style={{ maxWidth: '70vw', maxHeight: '70vh', width: '100%', height: 'auto', objectFit: 'contain' }}
         />
       )}
       {puedeGestionar && (


### PR DESCRIPTION
## Summary
- limit the news detail image dimensions to 70% of the viewport while keeping it responsive and centered

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416b3108d883208fc7db7068de2ce5)