### PR TITLE
Fix news club validation for populated news queries

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -2988,7 +2988,11 @@ app.get('/api/news/:id', async (req, res) => {
     if (!noticia) return res.status(404).json({ mensaje: 'Noticia no encontrada' });
 
     if (req.query?.clubId && isValidObjectId(req.query.clubId)) {
-      if (!noticia.club || noticia.club.toString() !== req.query.clubId) {
+      const noticiaClubId = noticia.club?._id
+        ? noticia.club._id.toString()
+        : noticia.club?.toString();
+
+      if (!noticiaClubId || noticiaClubId !== req.query.clubId) {
         return res.status(404).json({ mensaje: 'Noticia no encontrada en este club' });
       }
     }


### PR DESCRIPTION
## Summary
- ensure news detail requests compare the club id correctly even when the club is populated
- prevent erroneous 404 responses when accessing news for the correct club

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f68b2ffc8320b89f6f34d5e9fca1)