### PR TITLE
Use club contact endpoint in footer when club selected

### DIFF
--- a/frontend-auth/src/components/Footer.jsx
+++ b/frontend-auth/src/components/Footer.jsx
@@ -77,7 +77,8 @@ export default function Footer() {
   const fetchContactInfo = useCallback(async (clubId = getStoredClubId()) => {
     try {
       const config = clubId ? { params: { clubId } } : {};
-      const res = await api.get('/public/club-contact', config);
+      const endpoint = clubId ? '/clubs/contact' : '/public/club-contact';
+      const res = await api.get(endpoint, config);
       if (!mountedRef.current) return;
       applyContactInfo(res.data?.contactInfo || {}, clubId);
     } catch (err) {


### PR DESCRIPTION
## Summary
- fetch club contact info from the authenticated club endpoint when a club is selected
- keep public fallback for visitors without a selected club

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943fc6e411c8320ac185204f38c0c10)