### PR TITLE
Add Android push notifications for new content

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,6 +25,10 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    # MERCADOPAGO_ACCESS_TOKEN. El backend también acepta los alias
    # MERCADO_PAGO_ACCESS_TOKEN o MP_ACCESS_TOKEN para mayor compatibilidad
    # con distintos paneles de hosting.
+   # Para notificaciones push en la app Android configurá FCM_SERVER_KEY
+   # (o FIREBASE_SERVER_KEY). Es la clave del servidor de Firebase Cloud
+   # Messaging y se usa para enviar los avisos cuando se crean noticias,
+   # notificaciones, reportes y competencias.
    # UPLOADS_DIR defaults to backend-auth/uploads. If you have legacy
    # assets in another directory you can list them in
    # UPLOADS_FALLBACK_DIRS=/ruta/vieja/uploads

--- a/backend-auth/models/DeviceToken.js
+++ b/backend-auth/models/DeviceToken.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const deviceTokenSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    token: { type: String, required: true, unique: true, trim: true },
+    platform: { type: String, default: 'android' },
+    lastUsedAt: { type: Date, default: Date.now }
+  },
+  { timestamps: true }
+);
+
+const DeviceToken = mongoose.model('DeviceToken', deviceTokenSchema);
+export default DeviceToken;


### PR DESCRIPTION
## Summary
- add Firebase push delivery helpers and persist device tokens for authenticated users
- send push alerts when delegates/technicians publish news, competitions, notifications or athlete progress reports
- document the FCM server key requirement for Android push notifications

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f98f18cec8320aae7142997728393)