### PR TITLE
Agregar helpers de Firebase Admin FCM y envíos por tópico para noticias/competencias

### DIFF
--- a/backend-auth/package.json
+++ b/backend-auth/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "exceljs": "^4.3.0",
     "express": "^4.21.1",
+    "firebase-admin": "^12.0.0",
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",

--- a/backend-auth/utils/fcmV1.js
+++ b/backend-auth/utils/fcmV1.js
@@ -1,0 +1,47 @@
+import admin from 'firebase-admin';
+
+const getMessaging = () => {
+  if (!admin.apps.length) {
+    admin.initializeApp({ credential: admin.credential.applicationDefault() });
+  }
+  return admin.messaging();
+};
+
+const coerceData = (data = {}) =>
+  Object.fromEntries(
+    Object.entries(data)
+      .filter(([, value]) => typeof value !== 'undefined')
+      .map(([key, value]) => [key, String(value)])
+  );
+
+export const sendToToken = async ({ token, title, body, data = {} }) => {
+  if (!token) return;
+  const payload = {
+    token,
+    notification: {
+      title: title ?? '',
+      body: body ?? ''
+    }
+  };
+  const cleanedData = coerceData(data);
+  if (Object.keys(cleanedData).length > 0) {
+    payload.data = cleanedData;
+  }
+  await getMessaging().send(payload);
+};
+
+export const sendToTopic = async ({ topic, title, body, data = {} }) => {
+  if (!topic) return;
+  const payload = {
+    topic,
+    notification: {
+      title: title ?? '',
+      body: body ?? ''
+    }
+  };
+  const cleanedData = coerceData(data);
+  if (Object.keys(cleanedData).length > 0) {
+    payload.data = cleanedData;
+  }
+  await getMessaging().send(payload);
+};


### PR DESCRIPTION
### Motivation
- Proveer helpers que usen Firebase Admin SDK para simplificar el envío de FCM a tokens y tópicos en lugar de la lógica HTTP/OAuth manual existente.
- Emitir notificaciones por tópico a nivel de club cuando se crean noticias y competencias para que los clientes móviles las reciban fácilmente.
- Centralizar la normalización de `data` y la construcción segura de payloads para evitar valores `undefined` en los mensajes.

### Description
- Añadido `backend-auth/utils/fcmV1.js` que exporta `sendToToken` y `sendToTopic` usando `firebase-admin` y coerción de datos.
- Modificado `backend-auth/server.js` para importar los helpers y reemplazar el envío por token en `sendPushNotifications` para usar `sendToToken`.
- Agregadas llamadas a `sendToTopic` en los endpoints de creación de noticias y competencias para publicar en `topic: club_<clubId>`.
- Actualizado `backend-auth/package.json` para incluir la dependencia `firebase-admin` y ajustados los códigos de razones inválidas de tokens.

### Testing
- Se intentó instalar la dependencia con `npm install firebase-admin@^12.0.0`, pero la instalación falló con `403 Forbidden` contra el registry, por lo que la dependencia no quedó instalada.
- No se ejecutó ninguna suite de pruebas automatizadas sobre el cambio debido a la falla en la instalación de la dependencia.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614877a4d88320b640bee2ffb4b0a4)