### PR TITLE
Avoid cross-origin API fallbacks when VITE_API_BASE is set

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -47,6 +47,10 @@ const buildApiBaseUrlCandidates = () => {
     }
   }
 
+  if (rawEnvUrl) {
+    return unique(candidates);
+  }
+
   if (!isBrowser) {
     candidates.push(ensureApiSuffix('/'));
     return unique(candidates);


### PR DESCRIPTION
### Motivation

- The frontend can attempt cross-origin fallback hosts (e.g. switching between `patincarrera.net` and `www.patincarrera.net`) when the backend origin is temporarily unavailable, which can trigger CORS errors in production. 
- When a base API URL is explicitly provided via environment (`VITE_API_BASE` / `VITE_API_URL`) those fallbacks are unnecessary and harmful. 

### Description

- Changed `frontend-auth/src/api/index.js` to stop adding additional fallback candidate hosts when `VITE_API_BASE`/`VITE_API_URL` is set by returning early from `buildApiBaseUrlCandidates`. 
- This preserves the existing behaviour for local/dev runs while preventing accidental cross-origin retries in production. 
- The change is a small conditional insert that returns `unique(candidates)` if `rawEnvUrl` is present. 

### Testing

- No automated tests were run as part of this change. 
- Linting/build steps were not executed in this rollout. 
- Manual verification is recommended in a staging environment to confirm CORS/fallback behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c5f3d79c832088d7268b9c78ed30)