### PR TITLE
Permitir fallback a host alternativo cuando `VITE_API_BASE`/`VITE_API_URL` está configurado

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -48,6 +48,16 @@ const buildApiBaseUrlCandidates = () => {
   }
 
   if (rawEnvUrl) {
+    if (isBrowser) {
+      const { protocol, hostname } = window.location;
+      const hasWwwPrefix = hostname.startsWith('www.');
+      const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
+
+      if (alternateHost && alternateHost !== hostname) {
+        candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}`));
+      }
+    }
+
     return unique(candidates);
   }
 


### PR DESCRIPTION
### Motivation
- Evitar que el frontend quede inservible por 502/CORS cuando el dominio principal temporalmente falla, probando automáticamente el host alternativo con/sin `www` incluso si `VITE_API_BASE`/`VITE_API_URL` están configurados.

### Description
- Se actualizó `frontend-auth/src/api/index.js` para añadir el host alternativo (`www.` o sin `www`) a la lista de candidatos cuando `rawEnvUrl` está presente en el navegador, usando `ensureApiSuffix` para normalizar la URL antes de añadirla.
- Se preserva la lógica existente de normalización con `resolveConfiguredBase` y el orden de fallback dinámico para no introducir cambios de comportamiento en otros entornos.

### Testing
- No se ejecutaron pruebas automatizadas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a22389f58832084a37256ae7b28c1)