### PR TITLE
nginx: point root to frontend-auth build output

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -14,7 +14,7 @@ server {
     server_name patincarrera.net;
 
     # Serve the Vite build generated with `npm run build`
-    root /var/www/patincarrera/frontend/dist;
+    root /var/www/patincarrera/frontend-auth/dist;
     index index.html;
 
     # Allow large JSON bodies and uploads that the API already expects.


### PR DESCRIPTION
### Motivation
- The site was serving an old frontend build because Nginx `root` pointed to the previous `frontend/dist` directory instead of the current `frontend-auth` build output.

### Description
- Update the document root in `deployment/nginx.conf` from `/var/www/patincarrera/frontend/dist` to `/var/www/patincarrera/frontend-auth/dist` so the deployed server serves the latest Vite build.

### Testing
- No automated tests were run because this is a configuration-only change (no code behavior changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e591043088320b684e32b5b4bd9dd)