### PR TITLE
Validar clubId y manejar errores al cargar suscripción del club

### DIFF
--- a/backend-auth/utils/subscriptionUtils.js
+++ b/backend-auth/utils/subscriptionUtils.js
@@ -1,3 +1,4 @@
+import mongoose from 'mongoose';
 import Club from '../models/Club.js';
 
 import {
@@ -26,7 +27,18 @@ const shouldPersistDefaults = (options = {}) => {
 export const loadClubSubscription = async (clubId, options = {}) => {
   if (!clubId) return null;
 
-  const club = await Club.findById(clubId).select('nombre subscription');
+  if (!mongoose.Types.ObjectId.isValid(clubId)) {
+    console.warn('Club ID inválido recibido al cargar la suscripción del club.', clubId);
+    return null;
+  }
+
+  let club = null;
+  try {
+    club = await Club.findById(clubId).select('nombre subscription');
+  } catch (error) {
+    console.warn('No se pudo obtener la suscripción del club.', error);
+    return null;
+  }
   if (!club) return null;
 
   const persistDefaults = shouldPersistDefaults(options);


### PR DESCRIPTION
### Motivation
- Evitar que IDs de club inválidos o errores al consultar el modelo provoquen un 500 durante operaciones que cargan la suscripción (por ejemplo el login). 
- Hacer más robusta la función de carga de suscripción ante entradas malformadas o problemas de acceso a la base de datos.

### Description
- Se importó `mongoose` y se añadió una validación con `mongoose.Types.ObjectId.isValid(clubId)` para rechazar IDs inválidos y devolver `null` con un `console.warn`.
- Se envolvió la consulta `Club.findById(clubId).select('nombre subscription')` en un `try/catch` para capturar errores de consulta, registrar una advertencia y devolver `null` en caso de fallo.
- Cambios aplicados en `backend-auth/utils/subscriptionUtils.js` y se mantiene la lógica existente de persistencia de defaults y cálculo del estado de suscripción.

### Testing
- No se ejecutaron pruebas automatizadas sobre el cambio (ninguna prueba corrió).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5daf17b48320acce67ef0bf9bf48)