### PR TITLE
Guard against invalid HTTP requests before handing off to Express

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -11,6 +11,7 @@ import crypto from 'crypto';
 import nodemailer from 'nodemailer';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import http from 'http';
 import https from 'https';
 
 import User from './models/User.js';
@@ -4576,6 +4577,18 @@ app.get('/api/auth/google/callback', async (req, res) => {
 });
 
 const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
+const server = http.createServer((req, res) => {
+  if (!req || !req.method) {
+    console.error('Solicitud HTTP inválida recibida por el servidor.');
+    if (res) {
+      res.statusCode = 400;
+      res.end('Bad Request');
+    }
+    return;
+  }
+  app(req, res);
+});
+
+server.listen(PORT, () => {
   console.log(`Servidor escuchando en puerto ${PORT}`);
 });


### PR DESCRIPTION
### Motivation
- Evitar errores cuando llega una petición HTTP inválida (por ejemplo `req` nulo) que provocaba un `TypeError` dentro del ruteador de Express al leer `req.method`.

### Description
- Se añadió la importación de `http` y se reemplazó el arranque directo con `app.listen` por un servidor creado con `http.createServer` en `backend-auth/server.js`.
- El servidor ahora valida que la solicitud tenga un objeto `req` y una propiedad `method` antes de delegar a `app`, y responde `400 Bad Request` si la petición es inválida.
- Se mantiene la escucha en el mismo puerto (`process.env.PORT || 5000`) usando `server.listen` y se preserva el log de arranque.

### Testing
- No se ejecutaron tests automatizados sobre estos cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697625f02dc08320ba18acc721e83fd2)