### PR TITLE
Avoid cross-origin API fallbacks and return safe public defaults when Mongo is down

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -9,6 +9,8 @@ const ensureApiSuffix = (value) => {
 };
 
 const unique = (values) => Array.from(new Set(values.filter(Boolean)));
+const isAbsoluteUrl = (value) =>
+  typeof value === 'string' && (/^[a-z][a-z0-9+.-]*:\/\//i.test(value) || value.startsWith('//'));
 
 const resolveConfiguredBase = (rawUrl, origin) => {
   try {
@@ -30,6 +32,7 @@ const resolveConfiguredBase = (rawUrl, origin) => {
 const buildApiBaseUrlCandidates = () => {
   const rawEnvUrl =
     import.meta.env.VITE_API_BASE?.trim() || import.meta.env.VITE_API_URL?.trim();
+  const envIsRelative = rawEnvUrl ? !isAbsoluteUrl(rawEnvUrl) : false;
 
   const isBrowser = typeof window !== 'undefined';
   const candidates = [];
@@ -48,7 +51,7 @@ const buildApiBaseUrlCandidates = () => {
   }
 
   if (rawEnvUrl) {
-    if (isBrowser) {
+    if (isBrowser && !envIsRelative) {
       const { protocol, hostname } = window.location;
       const hasWwwPrefix = hostname.startsWith('www.');
       const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;


### PR DESCRIPTION
### Motivation

- Reduce browser startup errors (500/CORS) caused by the frontend trying cross‑origin fallbacks when `VITE_API_BASE` is a relative path. 
- Prevent public endpoints from returning 500 when MongoDB is not yet available by serving minimal safe defaults for clients.

### Description

- Frontend: added `isAbsoluteUrl` and `envIsRelative` checks in `frontend-auth/src/api/index.js` to avoid adding `www`/apex fallback candidates when `VITE_API_BASE`/`VITE_API_URL` is a relative path, preventing cross‑origin retries that trigger CORS errors. 
- Backend: added `isMongoReady()` helper and early fallback responses in `backend-auth/server.js` for `GET /api/public/app-config` to return `normaliseAppConfigResponse(null)` when Mongo is not connected. 
- Backend: added a Mongo-down fallback for `GET /api/public/club-contact` that returns a `LOCAL_CLUB`-based payload via `buildClubContactResponse(...)` to avoid 500s while the database is unavailable. 
- Modified files: `frontend-auth/src/api/index.js` and `backend-auth/server.js`.

### Testing

- No automated tests were executed as part of this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778d3c0324832097758dd68c635932)