### PR TITLE
fix: make pm2 cwd configurable

### DIFF
--- a/backend-auth/ecosystem.config.js
+++ b/backend-auth/ecosystem.config.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       name: 'patin-api',
       script: 'server.js',
-      cwd: '/home/deploy/apps/patincarreraGR/backend-auth',
+      cwd: process.env.PATIN_API_CWD || process.cwd(),
       instances: 1,
       exec_mode: 'fork',
       env: {


### PR DESCRIPTION
### Motivation
- Evitar que PM2 arranque el backend desde una ruta rígida que puede no existir en todos los despliegues y provocar que el proceso caiga (y con ello errores 502 en la web). 

### Description
- Reemplazado el `cwd` fijo en `backend-auth/ecosystem.config.js` por `process.env.PATIN_API_CWD || process.cwd()` para permitir configurar el directorio de trabajo vía la variable de entorno `PATIN_API_CWD` o usar el directorio actual como fallback.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b8fd496c832082813a7fe0d5708e)