### PR TITLE
Add alternate host fallback for relative API base

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -47,6 +47,22 @@ const buildApiBaseUrlCandidates = () => {
         resolveConfiguredBase(rawEnvUrl, window.location.origin) || normalised
       );
       if (configured) candidates.push(configured);
+
+      if (envIsRelative) {
+        const { protocol, hostname } = window.location;
+        const hasWwwPrefix = hostname.startsWith('www.');
+        const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
+
+        if (alternateHost && alternateHost !== hostname) {
+          const alternateConfigured = resolveConfiguredBase(
+            rawEnvUrl,
+            `${protocol}//${alternateHost}`
+          );
+          if (alternateConfigured) {
+            candidates.push(ensureApiSuffix(alternateConfigured));
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Evitar que la app quede bloqueada por errores 502 cuando `VITE_API_BASE` está configurado como ruta relativa (por ejemplo `/api`) y el origen actual no responde correctamente al iniciar sesión o al solicitar `/public/app-config` y `/public/club-contact`.

### Description
- Extendí `buildApiBaseUrlCandidates` en `frontend-auth/src/api/index.js` para que, cuando `VITE_API_BASE` sea relativo, también intente resolver la misma configuración usando el host alternativo con/sin `www.` via `resolveConfiguredBase` y lo añada a la lista de candidatas.
- La lógica calcula `alternateHost` a partir de `window.location.hostname` y empuja una entrada `alternateConfigured` normalizada cuando está disponible, conservando el comportamiento existente para variables absolutas y otros fallbacks.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio (ninguna solicitada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978e9d01d9c8320bc6f85f487bddd9e)