### PR TITLE
Add admin-managed "Categorías por edad" (backend + admin UI + patinador forms)

### DIFF
--- a/backend-auth/models/AppConfig.js
+++ b/backend-auth/models/AppConfig.js
@@ -12,6 +12,10 @@ const appConfigSchema = new mongoose.Schema(
     defaultBrandLogo: {
       type: String,
       default: ''
+    },
+    categoriasPorEdad: {
+      type: [String],
+      default: []
     }
   },
   {

--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -1,10 +1,25 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import api from '../api';
 
 export default function CargarPatinador() {
   const [mensaje, setMensaje] = useState('');
   const [fotoRostro, setFotoRostro] = useState(null);
   const [foto, setFoto] = useState(null);
+  const [categoriasPorEdad, setCategoriasPorEdad] = useState([]);
+
+  useEffect(() => {
+    const cargarCategorias = async () => {
+      try {
+        const res = await api.get('/public/app-config');
+        const categorias = Array.isArray(res.data?.categoriasPorEdad) ? res.data.categoriasPorEdad : [];
+        setCategoriasPorEdad(categorias);
+      } catch (err) {
+        console.error('Error al cargar las categorías por edad', err);
+      }
+    };
+
+    void cargarCategorias();
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -126,7 +141,18 @@ export default function CargarPatinador() {
           </div>
           <div className="col-md-6">
             <label className="form-label">Categoría</label>
-            <input type="text" className="form-control" name="categoria" required />
+            {categoriasPorEdad.length > 0 ? (
+              <select className="form-select" name="categoria" required>
+                <option value="">Seleccione</option>
+                {categoriasPorEdad.map((categoria) => (
+                  <option key={categoria} value={categoria}>
+                    {categoria}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input type="text" className="form-control" name="categoria" required />
+            )}
           </div>
           <div className="col-md-6">
             <label className="form-label">Foto Rostro</label>

--- a/frontend-auth/src/pages/EditarPatinador.jsx
+++ b/frontend-auth/src/pages/EditarPatinador.jsx
@@ -8,6 +8,7 @@ export default function EditarPatinador() {
   const [patinador, setPatinador] = useState(null);
   const [fotoRostro, setFotoRostro] = useState(null);
   const [foto, setFoto] = useState(null);
+  const [categoriasPorEdad, setCategoriasPorEdad] = useState([]);
 
   useEffect(() => {
     const obtenerPatinador = async () => {
@@ -20,6 +21,20 @@ export default function EditarPatinador() {
     };
     obtenerPatinador();
   }, [id]);
+
+  useEffect(() => {
+    const cargarCategorias = async () => {
+      try {
+        const res = await api.get('/public/app-config');
+        const categorias = Array.isArray(res.data?.categoriasPorEdad) ? res.data.categoriasPorEdad : [];
+        setCategoriasPorEdad(categorias);
+      } catch (err) {
+        console.error('Error al cargar las categorías por edad', err);
+      }
+    };
+
+    void cargarCategorias();
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -62,6 +77,10 @@ export default function EditarPatinador() {
   if (!patinador) {
     return <div className="container mt-4">Cargando...</div>;
   }
+
+  const categoriasOpciones = categoriasPorEdad.includes(patinador.categoria)
+    ? categoriasPorEdad
+    : [patinador.categoria, ...categoriasPorEdad].filter(Boolean);
 
   return (
     <div className="container mt-4">
@@ -229,13 +248,29 @@ export default function EditarPatinador() {
           </div>
           <div className="col-md-6">
             <label className="form-label">Categoría</label>
-            <input
-              type="text"
-              className="form-control"
-              name="categoria"
-              defaultValue={patinador.categoria}
-              required
-            />
+            {categoriasOpciones.length > 0 ? (
+              <select
+                className="form-select"
+                name="categoria"
+                defaultValue={patinador.categoria}
+                required
+              >
+                <option value="">Seleccione</option>
+                {categoriasOpciones.map((categoria) => (
+                  <option key={categoria} value={categoria}>
+                    {categoria}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                className="form-control"
+                name="categoria"
+                defaultValue={patinador.categoria}
+                required
+              />
+            )}
           </div>
           <div className="col-md-6">
             <label className="form-label">Foto Rostro</label>


### PR DESCRIPTION
### Motivation
- Permitir que el administrador pueda definir y reordenar el listado de categorías por edad porque las reglas de edad cambian cada año. 
- Exponer la configuración al frontend para usar un selector en los formularios de carga/edición de patinadores y para ordenar listados por la preferencia administrativa.

### Description
- Añadido campo `categoriasPorEdad` al modelo `AppConfig` (`backend-auth/models/AppConfig.js`) para almacenar el orden configurado por admin. 
- Implementadas utilidades en `server.js` para sanitizar, resolver y cachear el arreglo (`sanitizeCategoriasPorEdad`, `resolveCategoriasPorEdad`, `updateCategoriasPorEdadCache`) y `posCategoria` ahora usa la lista cacheada para ordenar. 
- Incluida la propiedad `categoriasPorEdad` en la respuesta pública de configuración y se actualiza la cache al iniciar y al servir `/api/public/app-config`. 
- Nuevos endpoints administrativos: `GET /api/admin/categories-by-age` y `PUT /api/admin/categories-by-age` para leer y actualizar la lista (requieren rol Admin). 
- Frontend: añadida sección «Categorías por edad» en `PanelAdmin.jsx` con tabla editable, botones para mover/ordenar/añadir/eliminar y guardado remoto; la UI carga y persiste mediante los endpoints nuevos. 
- Frontend: los formularios de `CargarPatinador.jsx` y `EditarPatinador.jsx` ahora consultan `public/app-config` para poblar un `select` de categorías si existen; si no, mantienen un campo libre como fallback.

### Testing
- Levanté el frontend localmente con `npm run dev` en `frontend-auth` y Vite informó "ready" (servidor dev disponible); esto se ejecutó correctamente. 
- Generé una captura de pantalla con un script de Playwright que navegó a `/admin` con `sessionStorage` simulando usuario `admin` y produjo el artefacto `artifacts/categorias-por-edad.png`, confirmando que la nueva sección se renderiza; el script finalizó con éxito. 
- No se ejecutaron tests unitarios automatizados adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6d86685c8320bde4a7ae7926477c)