### PR TITLE
Make www API fallback opt-in and add GET-404 bootstrap retries

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -33,6 +33,7 @@ const buildApiBaseUrlCandidates = () => {
   const rawEnvUrl =
     import.meta.env.VITE_API_BASE?.trim() || import.meta.env.VITE_API_URL?.trim();
   const envIsRelative = rawEnvUrl ? !isAbsoluteUrl(rawEnvUrl) : false;
+  const allowWwwFallback = import.meta.env.VITE_ALLOW_WWW_FALLBACK === 'true';
 
   const isBrowser = typeof window !== 'undefined';
   const candidates = [];
@@ -53,7 +54,12 @@ const buildApiBaseUrlCandidates = () => {
         const hasWwwPrefix = hostname.startsWith('www.');
         const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
 
-        if (alternateHost && alternateHost !== hostname) {
+        const backendPort = import.meta.env.VITE_BACKEND_PORT?.trim() || '5000';
+        if (backendPort) {
+          candidates.push(ensureApiSuffix(`${protocol}//${hostname}:${backendPort}`));
+        }
+
+        if (allowWwwFallback && alternateHost && alternateHost !== hostname) {
           const alternateConfigured = resolveConfiguredBase(
             rawEnvUrl,
             `${protocol}//${alternateHost}`
@@ -61,13 +67,17 @@ const buildApiBaseUrlCandidates = () => {
           if (alternateConfigured) {
             candidates.push(ensureApiSuffix(alternateConfigured));
           }
+
+          if (backendPort) {
+            candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}:${backendPort}`));
+          }
         }
       }
     }
   }
 
   if (rawEnvUrl) {
-    if (isBrowser && !envIsRelative) {
+    if (isBrowser && !envIsRelative && allowWwwFallback) {
       const { protocol, hostname } = window.location;
       const hasWwwPrefix = hostname.startsWith('www.');
       const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
@@ -108,10 +118,12 @@ const buildApiBaseUrlCandidates = () => {
   // upstream 502) try the alternate host with/without the `www.` prefix before
   // giving up. This keeps the app usable during brief outages handled by the
   // CDN or while the apex domain is being updated.
-  const hasWwwPrefix = hostname.startsWith('www.');
-  const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
-  if (alternateHost && alternateHost !== hostname) {
-    candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}`));
+  if (allowWwwFallback) {
+    const hasWwwPrefix = hostname.startsWith('www.');
+    const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
+    if (alternateHost && alternateHost !== hostname) {
+      candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}`));
+    }
   }
 
   return unique(candidates);
@@ -187,7 +199,24 @@ const shouldRetryWithFallback = (error) => {
 
   if (!status) return true;
 
-  return [500, 502, 503, 504, 521, 522, 523].includes(status);
+  if ([500, 502, 503, 504, 521, 522, 523].includes(status)) return true;
+
+  if (status === 404 && error.config?.method?.toLowerCase() === 'get') {
+    const requestPath = String(error.config.url || '');
+    const bootstrapEndpoints = [
+      'public/app-config',
+      'public/club-contact',
+      'public/clubs',
+      'federaciones',
+      'clubs',
+      'admin/categories-by-age'
+    ];
+    if (bootstrapEndpoints.some((endpoint) => requestPath.includes(endpoint))) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 api.interceptors.response.use(


### PR DESCRIPTION
### Motivation
- Prevent CORS/preflight failures caused by automatic fallbacks to `www.` hosts that trigger redirects and blocked preflights. 
- Improve bootstrapping resilience by retrying key read-only endpoints when the primary base returns a `404` so the client can rotate to alternate base URLs.

### Description
- Added an opt-in environment flag `VITE_ALLOW_WWW_FALLBACK` and updated `frontend-auth/src/api/index.js` to only include `www.` alternate host candidates when this flag is set. 
- When `VITE_API_BASE` is relative the code now prefers same-host backend port candidates (from `VITE_BACKEND_PORT`) before attempting cross-host `www.` fallbacks. 
- Extended `shouldRetryWithFallback` to treat `GET` `404` responses for key bootstrap endpoints (e.g. `public/app-config`, `public/club-contact`, `public/clubs`, `federaciones`, `clubs`, `admin/categories-by-age`) as retryable so the Axios instance will try other base URL candidates. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b80906ec8832096493241d2beaef6)