### PR TITLE
Fix backend port fallback selection

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -57,14 +57,8 @@ const buildApiBaseUrlCandidates = () => {
         const hasWwwPrefix = hostname.startsWith('www.');
         const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
 
-
         if (resolvedBackendPort) {
           candidates.push(ensureApiSuffix(`${protocol}//${hostname}:${resolvedBackendPort}`));
-
-        const backendPort = import.meta.env.VITE_BACKEND_PORT?.trim() || '5000';
-        if (backendPort) {
-          candidates.push(ensureApiSuffix(`${protocol}//${hostname}:${backendPort}`));
-
         }
 
         if (allowWwwFallback && alternateHost && alternateHost !== hostname) {
@@ -75,23 +69,10 @@ const buildApiBaseUrlCandidates = () => {
           if (alternateConfigured) {
             candidates.push(ensureApiSuffix(alternateConfigured));
           }
-
-
-          if (resolvedBackendPort) {
-            candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}:${resolvedBackendPort}`));
-
-          if (backendPort) {
-            candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}:${backendPort}`));
-          }
         }
 
-        const backendPort = import.meta.env.VITE_BACKEND_PORT?.trim() || '5000';
-        if (backendPort) {
-          candidates.push(ensureApiSuffix(`${protocol}//${hostname}:${backendPort}`));
-          if (alternateHost && alternateHost !== hostname) {
-            candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}:${backendPort}`));
-
-          }
+        if (resolvedBackendPort && allowWwwFallback && alternateHost && alternateHost !== hostname) {
+          candidates.push(ensureApiSuffix(`${protocol}//${alternateHost}:${resolvedBackendPort}`));
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Fix a build-time error caused by duplicate declaration of `backendPort` in `frontend-auth/src/api/index.js` that triggered `The symbol "backendPort" has already been declared` during Vite/esbuild transform. 
- Clarify and simplify the fallback candidate selection so port-based alternate-host candidates are only added once and under the correct conditions.

### Description
- Removed duplicated `backendPort` declarations and cleaned up nested conditional branches inside `buildApiBaseUrlCandidates`.
- Consolidated logic to only push port-based candidate URLs using `resolvedBackendPort` and to add alternate-host port entries when `allowWwwFallback` and an `alternateHost` apply.
- Changed file: `frontend-auth/src/api/index.js`.

### Testing
- No automated tests were run for this change.
- Changes were committed locally and the file was updated; build was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8c88d6d883209a7174a05ec4cbde)