### PR TITLE
Priorizar puerto del backend para API en localhost

### DIFF
--- a/frontend-auth/src/api/index.js
+++ b/frontend-auth/src/api/index.js
@@ -56,9 +56,17 @@ const buildApiBaseUrlCandidates = () => {
         const { protocol, hostname } = window.location;
         const hasWwwPrefix = hostname.startsWith('www.');
         const alternateHost = hasWwwPrefix ? hostname.replace(/^www\./i, '') : `www.${hostname}`;
+        const isLocalHost = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/i.test(hostname);
 
-        if (resolvedBackendPort) {
-          candidates.push(ensureApiSuffix(`${protocol}//${hostname}:${resolvedBackendPort}`));
+        const backendCandidate =
+          resolvedBackendPort && ensureApiSuffix(`${protocol}//${hostname}:${resolvedBackendPort}`);
+
+        if (backendCandidate) {
+          if (isLocalHost) {
+            candidates.unshift(backendCandidate);
+          } else {
+            candidates.push(backendCandidate);
+          }
         }
 
         if (allowWwwFallback && alternateHost && alternateHost !== hostname) {


### PR DESCRIPTION
### Motivation
- Evitar que, en desarrollo, las llamadas desde la app en localhost se queden apuntando al mismo origen y provocar errores 502 al resolver la URL del backend; preferir el candidato con el puerto del backend para que las peticiones vayan directo al servidor de desarrollo.

### Description
- Cambios en `frontend-auth/src/api/index.js` para crear un `backendCandidate` a partir de `VITE_BACKEND_PORT` y colocar ese candidato al principio de la lista (`unshift`) cuando el `hostname` sea `localhost`, `127.0.0.1` o `0.0.0.0`, manteniendo intacta la lógica de fallback para entornos de producción.

### Testing
- No se ejecutaron pruebas automáticas sobre el cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba6fb3a4883209c1baae024065454)