### PR TITLE
Remove duplicate normaliseAppConfigResponse definition

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -179,12 +179,6 @@ const parseBoolean = (value) => {
 };
 
 
-const normaliseAppConfigResponse = (config) => ({
-  defaultBrandLogo: typeof config?.defaultBrandLogo === 'string' ? config.defaultBrandLogo : '',
-  categoriasPorEdad: resolveCategoriasPorEdad(config?.categoriasPorEdad)
-});
-
-
 const isMongoReady = () => mongoose.connection.readyState === 1;
 
 // --------- Mongo URI ---------
@@ -424,11 +418,6 @@ const ORDEN_CATEGORIAS = [
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
 
 
-const normaliseAppConfigResponse = (config) => ({
-  defaultBrandLogo: typeof config?.defaultBrandLogo === 'string' ? config.defaultBrandLogo : '',
-  categoriasPorEdad: ORDEN_CATEGORIAS
-});
-
 let categoriasPorEdad = [...ORDEN_CATEGORIAS];
 
 const sanitizeCategoriasPorEdad = (raw) => {
@@ -452,6 +441,11 @@ const resolveCategoriasPorEdad = (raw) => {
   const sanitized = sanitizeCategoriasPorEdad(raw);
   return sanitized.length ? sanitized : ORDEN_CATEGORIAS;
 };
+
+const normaliseAppConfigResponse = (config) => ({
+  defaultBrandLogo: typeof config?.defaultBrandLogo === 'string' ? config.defaultBrandLogo : '',
+  categoriasPorEdad: resolveCategoriasPorEdad(config?.categoriasPorEdad)
+});
 
 const updateCategoriasPorEdadCache = (raw) => {
   categoriasPorEdad = resolveCategoriasPorEdad(raw);


### PR DESCRIPTION
### Motivation
- Evitar código duplicado y garantizar que la normalización de la configuración de la app use las categorías ya sanitizadas y resueltas.

### Description
- Eliminé la definición anterior duplicada de `normaliseAppConfigResponse` situada antes de la lógica de categorías.
- Reubicé y dejé una única implementación de `normaliseAppConfigResponse` inmediatamente después de `resolveCategoriasPorEdad` para que use `resolveCategoriasPorEdad(config?.categoriasPorEdad)`.
- Cambiado el archivo `backend-auth/server.js` para reflejar la modificación sin alterar otras referencias existentes a la función.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cbce33b108320bb90cea7472012c7)