### PR TITLE
Navbar: prevent brand navigation when logged out

### DIFF
--- a/frontend-auth/src/components/Navbar.jsx
+++ b/frontend-auth/src/components/Navbar.jsx
@@ -257,6 +257,11 @@ export default function Navbar() {
 
   const handleNavigate = (path) => navigate(path);
 
+  const handleBrandClick = () => {
+    if (!isLoggedIn) return;
+    handleNavigate('/home');
+  };
+
   const handleFileChange = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -350,8 +355,8 @@ export default function Navbar() {
       <div className="container">
         <a
           className="navbar-brand d-flex align-items-center"
-          onClick={() => handleNavigate('/home')}
-          style={{ cursor: 'pointer' }}
+          onClick={handleBrandClick}
+          style={{ cursor: isLoggedIn ? 'pointer' : 'default' }}
         >
           <img
             src={clubLogo || appDefaultLogo || defaultBrandLogo}


### PR DESCRIPTION
### Motivation
- Evitar que hacer click sobre el logo de la app en la navbar redirija a la sección de noticias u otra ruta cuando no hay un usuario logueado, y ajustar el cursor según el estado de sesión.

### Description
- Se añadió `handleBrandClick` que solo llama a `navigate('/home')` si `isLoggedIn` es truthy, se sustituyó el `onClick` del elemento de la marca para usar esta función, y se cambió `style.cursor` para mostrar `pointer` solo cuando el usuario está logueado (en caso contrario `default`).

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d13b2995c832088108d902e8821d0)