### PR TITLE
Permitir checkout y status de suscripción cuando el club está inactivo

### DIFF
--- a/backend-auth/middlewares/authMiddleware.js
+++ b/backend-auth/middlewares/authMiddleware.js
@@ -56,7 +56,11 @@ export const protegerRuta = async (req, res, next) => {
         };
 
         const requestPath = normalisePath(req.originalUrl) || normalisePath(rawPath);
-        const allowedInactivePaths = new Set(['/api/protegido/usuario']);
+        const allowedInactivePaths = new Set([
+          '/api/protegido/usuario',
+          '/api/subscriptions/checkout',
+          '/api/subscriptions/status'
+        ]);
         const isAllowed =
           allowedInactivePaths.has(requestPath) ||
           allowedInactivePaths.has(normalisePath(rawPath)) ||


### PR DESCRIPTION
### Motivation
- Evitar que la validación de suscripción inactiva impida completar el proceso de pago tras vencerse el período de prueba, permitiendo que los endpoints de checkout y estado de suscripción sigan funcionando.

### Description
- Se actualizó `backend-auth/middlewares/authMiddleware.js` para incluir `/api/subscriptions/checkout` y `/api/subscriptions/status` en el conjunto `allowedInactivePaths`, de modo que esas rutas no sean bloqueadas cuando `subscriptionState.isActive` sea falso.

### Testing
- No se ejecutaron tests automáticos como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4699fe3c8320927f527842306056)