### PR TITLE
Permitir flujos de pago con suscripciones inactivas y ajustar selección de Mercado Pago en UI

### DIFF
--- a/backend-auth/middlewares/authMiddleware.js
+++ b/backend-auth/middlewares/authMiddleware.js
@@ -58,6 +58,7 @@ export const protegerRuta = async (req, res, next) => {
         const requestPath = normalisePath(req.originalUrl) || normalisePath(rawPath);
         const allowedInactivePaths = new Set([
           '/api/protegido/usuario',
+          '/api/payments/methods',
           '/api/subscriptions/checkout',
           '/api/subscriptions/status'
         ]);

--- a/frontend-auth/src/pages/Suscripciones.jsx
+++ b/frontend-auth/src/pages/Suscripciones.jsx
@@ -320,14 +320,12 @@ export default function Suscripciones() {
 
   const handlePaymentMethodTypeChange = (event) => {
     const value = event.target.value;
-    if (value === 'mercadopago' && !mercadoPagoAvailable) {
-      setErrorMessage('Mercado Pago no está disponible en este momento. Elegí una tarjeta guardada para continuar.');
-      setPaymentMethodType('card');
-      return;
-    }
     setPaymentMethodType(value);
     setCheckoutResult(null);
     resetMessages();
+    if (value === 'mercadopago' && !mercadoPagoAvailable) {
+      setErrorMessage('Mercado Pago no está disponible en este momento. Elegí una tarjeta guardada para continuar.');
+    }
     if (value !== 'card') {
       setSelectedMethodId('');
     }
@@ -447,6 +445,10 @@ export default function Suscripciones() {
     if (paymentMethodType === 'card' && !selectedMethodId) {
       setCardErrors((prev) => ({ ...prev, general: 'Seleccioná una tarjeta guardada.' }));
       setErrorMessage('Seleccioná una tarjeta guardada para continuar.');
+      return;
+    }
+    if (paymentMethodType === 'mercadopago' && !mercadoPagoAvailable) {
+      setErrorMessage('Mercado Pago no está disponible en este momento. Elegí una tarjeta guardada para continuar.');
       return;
     }
 
@@ -667,7 +669,6 @@ export default function Suscripciones() {
                       id="payment-method-mercado-pago"
                       value="mercadopago"
                       checked={paymentMethodType === 'mercadopago'}
-                      disabled={!mercadoPagoAvailable}
                       onChange={handlePaymentMethodTypeChange}
                     />
                     <label className="form-check-label" htmlFor="payment-method-mercado-pago">


### PR DESCRIPTION
### Motivation
- Resolver que clubes con la suscripción inactiva no puedan gestionar/usar métodos de pago guardados y facilitar la regularización del pago desde la UI.
- Evitar que la opción de `Mercado Pago` quede bloqueada en la interfaz impidiendo que el usuario vea el mensaje de indisponibilidad y proceda con una alternativa.

### Description
- Backend: permito explícitamente que el endpoint de métodos de pago sea accesible aun cuando la suscripción del club esté inactiva añadiendo `'/api/payments/methods'` a la lista `allowedInactivePaths` en `backend-auth/middlewares/authMiddleware.js`.
- Frontend: en `frontend-auth/src/pages/Suscripciones.jsx` quito la deshabilitación del radio de `mercadopago` para que pueda seleccionarse visualmente, muestro un mensaje informativo si `mercadoPagoAvailable` es `false`, y bloqueo el intento de `checkout` cuando `mercadopago` no está disponible devolviendo un error claro; también cambio la lógica para no forzar el retorno a `card` al seleccionar `mercadopago`.

### Testing
- No se ejecutaron tests automáticos sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd122b4888320837fe69f50534024)