### PR TITLE
Forzar categorías mayores para deportistas adultos

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -415,6 +415,7 @@ const ORDEN_CATEGORIAS = [
   'CHP','M7DE','M7VE','PDE','PVE','6DE','6VE','5DE','5VE','4DE','4VE','JDE','JVE','MDE','MVE',
   'PDT','PVT','6DT','6VT','5DT','5VT','4DT','4VT','JDI','JVI','MDI','MVI','PDF','PVF','6DF','6VF','5DF','5VF','4DF','4VF','JDF','JVF','MDF','MVF'
 ];
+const CATEGORIAS_MAYORES = ['MDE', 'MVE', 'MDI', 'MVI', 'MDF', 'MVF'];
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
 
 
@@ -559,6 +560,10 @@ const inferCategoriaPorEdad = ({ edad, sexo, nivel, config }) => {
   const sexoCodigo = sexoToCodigo(sexo);
   const nivelCodigo = nivelToCodigo(nivel);
   if (!sexoCodigo || !nivelCodigo) return null;
+  if (edadValue >= 18) {
+    const categoriaMayor = `M${sexoCodigo}${nivelCodigo}`;
+    return CATEGORIAS_MAYORES.includes(categoriaMayor) ? categoriaMayor : null;
+  }
   const categoriasConfig = buildCategoriasPorEdadEdades(config);
   const candidatas = categoriasConfig.filter((item) => item.edades.includes(edadValue));
   const filtradas = candidatas


### PR DESCRIPTION
### Motivation
- Garantizar que cualquier deportista de 18 años o más sea asignado por defecto a una categoría "Mayores" según su sexo y nivel (las categorías: `MDE`, `MVE`, `MDI`, `MVI`, `MDF`, `MVF`).

### Description
- Se añadió la constante `CATEGORIAS_MAYORES` con la lista `['MDE','MVE','MDI','MVI','MDF','MVF']` y se modificó `inferCategoriaPorEdad` para que, si `edad >= 18`, construya `M${sexoCodigo}${nivelCodigo}` y la devuelva cuando pertenezca a `CATEGORIAS_MAYORES`.

### Testing
- No se ejecutaron tests automatizados en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2cc0c484832088dc7fc7ed3ae7c4)