### PR TITLE
Corregir inferencia de categoría para patinadores mayores de 18 años

### DIFF
--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -64,6 +64,11 @@ export default function CargarPatinador() {
     const sexoCodigo = sexoToCodigo(sexoValue);
     const nivelCodigo = nivelToCodigo(nivelValue);
     if (!sexoCodigo || !nivelCodigo) return '';
+    if (edadNumero >= 18) {
+      const categoriasMayores = ['MDE', 'MVE', 'MDI', 'MVI', 'MDF', 'MVF'];
+      const categoriaMayor = `M${sexoCodigo}${nivelCodigo}`;
+      return categoriasMayores.includes(categoriaMayor) ? categoriaMayor : '';
+    }
     const candidatas = (categoriasConfig || []).filter((item) =>
       Array.isArray(item.edades) && item.edades.includes(edadNumero)
     );


### PR DESCRIPTION
### Motivation
- Se corrigió que no se asignaba categoría a patinadores mayores de 18 años porque la inferencia en el frontend no contemplaba el mapeo a las categorías `M…` para adultos.

### Description
- Añadida lógica en `inferirCategoria` en `frontend-auth/src/pages/CargarPatinador.jsx` para cuando `edad >= 18` construir `categoriaMayor = 'M' + sexoCodigo + nivelCodigo` y devolverla si está en `['MDE','MVE','MDI','MVI','MDF','MVF']`, preservando la lógica existente para menores.

### Testing
- No se ejecutaron tests automatizados sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e35d46a488320a39e8bd76633a92c)