### PR TITLE
Add FCM notification metadata and request runtime notification permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,12 @@
     <application
         android:label="PatinCarrera"
         android:icon="@android:drawable/ic_dialog_info">
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@android:drawable/ic_dialog_info" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="patincarrera_general" />
         <service
             android:name=".PatinFirebaseMessagingService"
             android:exported="false">

--- a/android/app/src/main/java/com/zuria/patincarrera/MainActivity.java
+++ b/android/app/src/main/java/com/zuria/patincarrera/MainActivity.java
@@ -1,8 +1,12 @@
 package com.zuria.patincarrera;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import android.widget.TextView;
@@ -28,5 +32,17 @@ public class MainActivity extends AppCompatActivity {
         });
 
         setContentView(root);
+        requestNotificationPermissionIfNeeded();
+    }
+
+    private void requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return;
+        }
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            == PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+        requestPermissions(new String[] { Manifest.permission.POST_NOTIFICATIONS }, 1001);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure Firebase Cloud Messaging displays notifications correctly by providing default icon and channel metadata and by obtaining the Android 13+ runtime notification permission.

### Description
- Add FCM default notification metadata (`com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_channel_id`) to `android/app/src/main/AndroidManifest.xml` so FCM can use a default icon and channel ID.
- Add a runtime permission flow for `POST_NOTIFICATIONS` in `android/app/src/main/java/com/zuria/patincarrera/MainActivity.java`, including necessary imports and a call to `requestNotificationPermissionIfNeeded()` from `onCreate` to request permission on Android 13+ (TIRAMISU).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d57d066c8320b4eda7090a6a47d1)