### PR TITLE
Add debug log in onNewToken to print FCM token (testing)

### DIFF
--- a/android/app/src/main/java/com/zuria/patincarrera/PatinFirebaseMessagingService.java
+++ b/android/app/src/main/java/com/zuria/patincarrera/PatinFirebaseMessagingService.java
@@ -25,6 +25,7 @@ public class PatinFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onNewToken(String token) {
         super.onNewToken(token);
+        android.util.Log.d("FCM_TOKEN", token);
         registerTokenWithBackend(this, token);
     }
 


### PR DESCRIPTION
### Motivation
- Añadir un log temporal para capturar el token FCM cuando se refresca en `PatinFirebaseMessagingService.onNewToken` con fines de prueba. 

### Description
- Se agregó `android.util.Log.d("FCM_TOKEN", token);` en `android/app/src/main/java/com/zuria/patincarrera/PatinFirebaseMessagingService.java` justo antes de `registerTokenWithBackend(this, token);`.

### Testing
- Se inspeccionó el archivo y el diff con `rg`/`sed` y `git diff` para verificar el cambio, los cuales completaron correctamente.  
- Se realizó el commit con `git commit` que retornó éxito; no se ejecutaron tests unitarios adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846b1104a88320a700525cb337ca41)