### PR TITLE
Asignar categoría por año de nacimiento y editar años en Admin

### DIFF
--- a/backend-auth/models/AppConfig.js
+++ b/backend-auth/models/AppConfig.js
@@ -22,6 +22,7 @@ const appConfigSchema = new mongoose.Schema(
       type: [
         {
           categoria: { type: String, required: true },
+          aniosNacimiento: { type: [Number], default: [] },
           edades: { type: [Number], default: [] }
         }
       ],

--- a/frontend-auth/src/pages/PanelAdmin.jsx
+++ b/frontend-auth/src/pages/PanelAdmin.jsx
@@ -124,7 +124,7 @@ export default function PanelAdmin() {
       setCategoriasPorEdad(
         categorias.map((item) => ({
           categoria: item.categoria,
-          edadesInput: Array.isArray(item.edades) ? item.edades.join(', ') : ''
+          aniosNacimientoInput: Array.isArray(item.aniosNacimiento) ? item.aniosNacimiento.join(', ') : ''
         }))
       );
 
@@ -322,20 +322,20 @@ export default function PanelAdmin() {
 
   const handleCategoriaChange = (index, value) => {
     setCategoriasPorEdad((prev) =>
-      prev.map((item, idx) => (idx === index ? { ...item, edadesInput: value } : item))
+      prev.map((item, idx) => (idx === index ? { ...item, aniosNacimientoInput: value } : item))
     );
     setCategoriasDirty(true);
   };
 
   const handleCategoriasSave = async () => {
     const categoriasPayload = categoriasPorEdad.map((item) => {
-      const edades = (item.edadesInput || '')
+      const aniosNacimiento = (item.aniosNacimientoInput || '')
         .split(/[,;]+/)
         .map((value) => Number.parseInt(value.trim(), 10))
-        .filter((value) => Number.isFinite(value) && value > 0 && value <= 120);
+        .filter((value) => Number.isFinite(value) && value >= 1900 && value <= 2100);
       return {
         categoria: item.categoria,
-        edades
+        aniosNacimiento
       };
     });
 
@@ -348,7 +348,7 @@ export default function PanelAdmin() {
       setCategoriasPorEdad(
         updated.map((item) => ({
           categoria: item.categoria,
-          edadesInput: Array.isArray(item.edades) ? item.edades.join(', ') : ''
+          aniosNacimientoInput: Array.isArray(item.aniosNacimiento) ? item.aniosNacimiento.join(', ') : ''
         }))
       );
 
@@ -631,9 +631,9 @@ export default function PanelAdmin() {
       <section className="mt-4">
         <div className="card shadow-sm">
           <div className="card-body">
-            <h2 className="h4 mb-3">Categorías por edad</h2>
+            <h2 className="h4 mb-3">Categorías por año de nacimiento</h2>
             <p className="text-muted small mb-4">
-              Actualizá las edades que componen cada categoría sin cambiar el orden oficial.
+              Actualizá los años de nacimiento que componen cada categoría sin cambiar el orden oficial.
             </p>
             <div className="table-responsive">
               <table className="table table-striped align-middle">
@@ -641,7 +641,7 @@ export default function PanelAdmin() {
                   <tr>
                     <th style={{ width: '80px' }}>Orden</th>
                     <th>Categoría</th>
-                    <th>Edades</th>
+                    <th>Años de nacimiento</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -653,9 +653,9 @@ export default function PanelAdmin() {
                         <input
                           type="text"
                           className="form-control"
-                          value={item.edadesInput}
+                          value={item.aniosNacimientoInput}
                           onChange={(event) => handleCategoriaChange(index, event.target.value)}
-                          placeholder="Ej: 13, 14"
+                          placeholder="Ej: 2011, 2012"
                           disabled={categoriasLoading}
                         />
                       </td>


### PR DESCRIPTION
### Motivation
- Corregir la lógica de asignación de categoría para que dependa del **año de nacimiento** (no de la edad) al cargar nuevos patinadores, y mantener la regla de mayores de 18 años cuya categoría inicia con la letra `M`.
- Permitir que los administradores editen los rangos por categoría usando **años de nacimiento** en lugar de edades para evitar ambigüedades al inferir categorías.

### Description
- Se amplió el esquema `AppConfig` para incluir `aniosNacimiento` por categoría manteniendo `edades` para compatibilidad (`backend-auth/models/AppConfig.js`).
- Nuevo procesamiento en el backend: `sanitizeAniosNacimiento`, `buildCategoriasPorEdadAnioNacimiento` y `inferCategoriaPorAnioNacimiento` reemplazan la lógica previa basada en edad y aceptan de forma retrocompatible `edades` cuando `aniosNacimiento` no está presente (`backend-auth/server.js`).
- Al crear un patinador la categoría ahora se calcula con `anioNacimiento = fechaNacimiento.getFullYear()` y `inferCategoriaPorAnioNacimiento`, y sigue aplicando la regla de mayores de 18 años que genera categorías con prefijo `M` (`/api/patinadores`).
- Cambios en la UI: `CargarPatinador.jsx` ahora infiere categoría desde la `fechaNacimiento` (año) y `PanelAdmin.jsx` reemplaza la columna/inputs de "Edades" por "Años de nacimiento" (payload y validación ajustados a años entre `1900` y `2100`).
- Compatibilidad: si la configuración disponible sigue usando `edades`, el backend la acepta y la convierte internamente a `aniosNacimiento` para no romper datos existentes.

### Testing
- Ejecuté `npm --prefix frontend-auth run lint` y la comprobación de lint pasó (`eslint` success).
- Ejecuté `npm --prefix frontend-auth run build` y la build de la UI finalizó correctamente (`vite build` success).
- Ejecuté `node --check backend-auth/server.js` para verificar sintaxis del backend y no reportó errores (success).
- Intenté `npm --prefix backend-auth test` pero falló porque el `package.json` del backend no define un `test` script (failure: no test script).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850eb3759c83209d676cd30fcfe759)