### PR TITLE
Restringir categoría CHP a año 2022 o anterior

### DIFF
--- a/backend-auth/server.js
+++ b/backend-auth/server.js
@@ -487,6 +487,14 @@ const sanitizeAniosNacimiento = (raw) => {
   return Array.from(unique).sort((a, b) => a - b);
 };
 
+const applyCategoriaAnioRules = (categoria, aniosNacimiento = []) => {
+  if (!Array.isArray(aniosNacimiento)) return [];
+  if (categoria === 'CHP') {
+    return aniosNacimiento.filter((anio) => anio <= 2022);
+  }
+  return aniosNacimiento;
+};
+
 const buildCategoriasPorEdadAnioNacimiento = (config) => {
   const stored = Array.isArray(config?.categoriasPorEdadEdades)
     ? config.categoriasPorEdadEdades
@@ -497,7 +505,7 @@ const buildCategoriasPorEdadAnioNacimiento = (config) => {
     const categoria = String(item.categoria).trim();
     if (!ORDEN_CATEGORIAS.includes(categoria)) return;
     const origen = item.aniosNacimiento ?? item.edades;
-    byCategoria.set(categoria, sanitizeAniosNacimiento(origen));
+    byCategoria.set(categoria, applyCategoriaAnioRules(categoria, sanitizeAniosNacimiento(origen)));
   });
 
   return ORDEN_CATEGORIAS.map((categoria) => ({
@@ -2795,7 +2803,7 @@ app.put('/api/admin/categories-by-age', protegerRuta, permitirRol('Admin'), asyn
         const categoria = String(item.categoria).trim();
         if (!ORDEN_CATEGORIAS.includes(categoria)) return;
         const origen = item.aniosNacimiento ?? item.edades;
-        byCategoria.set(categoria, sanitizeAniosNacimiento(origen));
+        byCategoria.set(categoria, applyCategoriaAnioRules(categoria, sanitizeAniosNacimiento(origen)));
       });
 
       const categoriasPorEdadEdades = ORDEN_CATEGORIAS.map((categoria) => ({


### PR DESCRIPTION
### Motivation
- Evitar que la categoría `CHP` incluya años de nacimiento posteriores a 2022, normalizando tanto la configuración existente como las cargas nuevas.

### Description
- Agregué la función `applyCategoriaAnioRules(categoria, aniosNacimiento)` que aplica reglas por categoría y filtra los años para `CHP` a `<= 2022`.
- Apliqué esa función al construir la respuesta de configuración en `buildCategoriasPorEdadAnioNacimiento` para normalizar datos persistidos.
- Apliqué la misma normalización al procesar el endpoint `PUT /api/admin/categories-by-age` para sanitizar y guardar entradas recibidas.

### Testing
- Ejecuté `node --check backend-auth/server.js` para validar la sintaxis del archivo modificado y la verificación pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852bc451788320b7ed34240d5090e6)