### PR TITLE
Fix CHP category auto-selection for 2022 birth year

### DIFF
--- a/frontend-auth/src/pages/CargarPatinador.jsx
+++ b/frontend-auth/src/pages/CargarPatinador.jsx
@@ -44,6 +44,7 @@ export default function CargarPatinador() {
 
   const matchesCategoriaSexo = (categoriaValue, sexoCodigo) => {
     if (!categoriaValue || !sexoCodigo) return false;
+    if (categoriaValue === 'CHP') return true;
     const esM7 = categoriaValue.startsWith('M7');
     const index = esM7 ? 2 : 1;
     const sexoChar = categoriaValue[index];
@@ -53,6 +54,7 @@ export default function CargarPatinador() {
 
   const matchesCategoriaNivel = (categoriaValue, nivelCodigo) => {
     if (!categoriaValue || !nivelCodigo) return false;
+    if (categoriaValue === 'CHP') return true;
     const lastChar = categoriaValue[categoriaValue.length - 1];
     if (!['E', 'T', 'I', 'F'].includes(lastChar)) return false;
     return lastChar === nivelCodigo;


### PR DESCRIPTION
### Motivation
- Evitar que al cargar patinadores nacidos en 2022 aparezca el error "No se encontró una categoría con el año de nacimiento, sexo y nivel seleccionados" porque la categoría especial `CHP` no encaja en el mismo esquema de sufijos de sexo/nivel que otras categorías.

### Description
- En `frontend-auth/src/pages/CargarPatinador.jsx` añadí una excepción en `matchesCategoriaSexo` y `matchesCategoriaNivel` para que `CHP` se considere válida durante la inferencia de categoría.

### Testing
- Ejecuté el lint del frontend con `npm --prefix frontend-auth run lint` y terminó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852e1e6a1483209d11dd76598df250)