### PR TITLE
Align FCM web registration flow with push endpoint

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -80,9 +80,9 @@ This project can be deployed on an Ubuntu VPS (e.g. Hostinger) with the domain `
    ```xml
    <string name="backend_base_url">https://patincarrera.net</string>
    ```
-3. El backend espera el endpoint `/api/device-tokens` con el token FCM; el
-   servicio de mensajería Android lo envía si encuentra un auth token en
-   SharedPreferences (clave `auth_token`).
+3. El backend acepta `/api/device-tokens` (compatibilidad) y `/api/push/register`
+   para registrar tokens FCM; el servicio de mensajería Android envía el token
+   si encuentra un auth token en SharedPreferences (clave `auth_token`).
 
  ## 4. Nginx
 1. Copy the provided configuration:

--- a/frontend-auth/public/firebase-messaging-sw.js
+++ b/frontend-auth/public/firebase-messaging-sw.js
@@ -2,34 +2,27 @@
 importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js');
 
-const params = new URLSearchParams(self.location.search);
-const firebaseConfig = {
-  apiKey: params.get('apiKey'),
-  authDomain: params.get('authDomain'),
-  projectId: params.get('projectId'),
-  storageBucket: params.get('storageBucket'),
-  messagingSenderId: params.get('messagingSenderId'),
-  appId: params.get('appId')
-};
+firebase.initializeApp({
+  apiKey: 'TU_WEB_API_KEY',
+  authDomain: 'TU_AUTH_DOMAIN',
+  projectId: 'patincarreragr-788d3',
+  storageBucket: 'patincarreragr-788d3.firebasestorage.app',
+  messagingSenderId: '282799184125',
+  appId: 'TU_WEB_APP_ID'
+});
 
-const hasConfig = Object.values(firebaseConfig).every((value) => value);
+const messaging = firebase.messaging();
 
-if (hasConfig) {
-  firebase.initializeApp(firebaseConfig);
-  const messaging = firebase.messaging();
-
-  messaging.onBackgroundMessage((payload) => {
-    const notification = payload?.notification || {};
-    const title = notification.title || 'Patín Carrera';
-    const options = {
-      body: notification.body || '',
-      icon: '/patincarrera-favicon.svg',
-      badge: '/patincarrera-favicon.svg',
-      data: payload?.data || {}
-    };
-    self.registration.showNotification(title, options);
-  });
-}
+messaging.onBackgroundMessage((payload) => {
+  const title = payload?.notification?.title || 'Patín Carrera';
+  const options = {
+    body: payload?.notification?.body || '',
+    icon: '/patincarrera-favicon.svg',
+    badge: '/patincarrera-favicon.svg',
+    data: payload?.data || {}
+  };
+  self.registration.showNotification(title, options);
+});
 
 self.addEventListener('notificationclick', (event) => {
   event.notification?.close();


### PR DESCRIPTION
### Motivation
- Unificar y endurecer el flujo de registro de tokens FCM para web y mantener compatibilidad con clientes Android antiguos. 
- Evitar problemas con el service worker cuando se usan `import.meta.env` dentro del SW y asegurar que el SW se sirva desde la raíz del dominio.

### Description
- Se extrajo un handler compartido `registerDeviceToken` que valida el `token`, acepta opcionalmente `userId` y comprueba permisos, y se expone en `POST /api/device-tokens` (compatibilidad) y `POST /api/push/register` (nuevo endpoint). 
- El cliente web de push ahora registra el service worker desde la ruta fija `/firebase-messaging-sw.js`, envía el token a `POST /api/push/register` y adjunta `userId` desde `sessionStorage` cuando esté disponible (`frontend-auth/src/utils/pushNotifications.js`). 
- Se reemplazó la versión query-param del service worker por una variante estática con placeholders (sin depender de `import.meta.env`) y se ubicó en la raíz (`frontend-auth/public/firebase-messaging-sw.js`). 
- Se actualizó `DEPLOYMENT.md` para documentar que el backend acepta ambos endpoints de registro (`/api/device-tokens` y `/api/push/register`).

### Testing
- Ejecutado `node --check server.js` en `backend-auth` para verificar sintaxis y la comprobación fue exitosa. 
- Ejecutado `npm run build` en `frontend-auth` para compilar la app con Vite y la compilación fue exitosa. 
- Ejecutado `npm test -- --runInBand` en `backend-auth` y falló porque no existe un script `test` definido; esto se reporta como `no tests defined`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ac2d2a9883209aefb078b64ba1de)