### PR TITLE
Add /api/push router, PushToken model and Firebase Admin initializer

### DIFF
--- a/backend-auth/models/PushToken.js
+++ b/backend-auth/models/PushToken.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const pushTokenSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true, index: true },
+    token: { type: String, required: true, unique: true, trim: true },
+    platform: { type: String, enum: ['web', 'android'], required: true },
+    device: { type: String, trim: true },
+    lastSeenAt: { type: Date, default: Date.now }
+  },
+  { timestamps: true }
+);
+
+const PushToken = mongoose.model('PushToken', pushTokenSchema);
+export default PushToken;

--- a/backend-auth/routes/push.js
+++ b/backend-auth/routes/push.js
@@ -1,0 +1,63 @@
+import express from 'express';
+import PushToken from '../models/PushToken.js';
+import { initFirebaseAdmin } from '../src/firebaseAdmin.js';
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  try {
+    const { userId, token, platform, device } = req.body;
+
+    if (!userId || !token || !platform) {
+      return res.status(400).json({ ok: false, error: 'userId, token, platform son requeridos' });
+    }
+
+    await PushToken.updateOne(
+      { token },
+      { $set: { userId, token, platform, device, lastSeenAt: new Date() } },
+      { upsert: true }
+    );
+
+    return res.json({ ok: true });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/test', async (req, res) => {
+  try {
+    const { userId, title = 'Prueba', body = 'Push OK', data = {} } = req.body;
+    if (!userId) return res.status(400).json({ ok: false, error: 'userId requerido' });
+
+    const admin = initFirebaseAdmin();
+
+    const tokens = await PushToken.find({ userId }).lean();
+    if (!tokens.length) return res.status(404).json({ ok: false, error: 'No hay tokens para este userId' });
+
+    const base = {
+      notification: { title, body },
+      data: Object.fromEntries(Object.entries(data).map(([k, v]) => [String(k), String(v)])),
+      android: { priority: 'high', notification: { channelId: 'patincarrera_default' } },
+      webpush: {
+        headers: { Urgency: 'high' },
+        notification: { icon: '/icons/icon-192.png', badge: '/icons/badge-72.png' }
+      }
+    };
+
+    const sent = [];
+    for (const t of tokens) {
+      try {
+        const id = await admin.messaging().send({ ...base, token: t.token });
+        sent.push({ token: t.token, ok: true, messageId: id });
+      } catch (err) {
+        sent.push({ token: t.token, ok: false, error: err.message });
+      }
+    }
+
+    return res.json({ ok: true, sent });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+export default router;

--- a/backend-auth/src/firebaseAdmin.js
+++ b/backend-auth/src/firebaseAdmin.js
@@ -1,0 +1,21 @@
+import admin from 'firebase-admin';
+
+function initFirebaseAdmin() {
+  if (admin.apps.length) return admin;
+
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = (process.env.FIREBASE_PRIVATE_KEY || '').replace(/\\n/g, '\n');
+
+  if (!projectId || !clientEmail || !privateKey) {
+    throw new Error('Faltan envs Firebase Admin (PROJECT_ID / CLIENT_EMAIL / PRIVATE_KEY)');
+  }
+
+  admin.initializeApp({
+    credential: admin.credential.cert({ projectId, clientEmail, privateKey })
+  });
+
+  return admin;
+}
+
+export { admin, initFirebaseAdmin };


### PR DESCRIPTION
### Motivation
- Provide a dedicated, modular API to register push tokens and send test pushes using Firebase Admin. 
- Persist push registrations in MongoDB with a lightweight `PushToken` model so multiple devices/tokens per user can be addressed. 
- Centralize Firebase Admin initialization and avoid duplicating inline handlers in `server.js`.

### Description
- Added `backend-auth/models/PushToken.js` which defines the `PushToken` mongoose model with `userId`, `token`, `platform`, `device`, `lastSeenAt` and `timestamps`.
- Added `backend-auth/src/firebaseAdmin.js` with `initFirebaseAdmin()` that validates `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL` and `FIREBASE_PRIVATE_KEY` and initializes `firebase-admin` once.
- Added `backend-auth/routes/push.js` which exposes `POST /register` to upsert tokens and `POST /test` to send a test notification to all tokens for a `userId` using `admin.messaging().send()` and stringified `data` payload.
- Wired the router into the app with `app.use('/api/push', pushRoutes)` and removed the older inline `/api/push/register` and `/api/push/test` handlers to prevent duplication while keeping existing `/api/device-tokens` behavior.

### Testing
- Performed syntax checks with `node --check server.js`, `node --check routes/push.js`, `node --check src/firebaseAdmin.js` and `node --check models/PushToken.js`, all of which completed successfully.
- Verified route wiring by inspecting `server.js` to ensure `import pushRoutes from './routes/push.js'` and `app.use('/api/push', pushRoutes)` are present and the old inline handlers were removed.
- Confirmed `utils/fcmV1.js` remains for existing `sendToToken`/`sendToTopic` functionality and the new `routes/push.js` uses `initFirebaseAdmin()` for admin messaging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b1c772e083208ce8328c62636b9d)