### PR TITLE
Agregar inicializador de Firebase Admin en backend

### DIFF
--- a/backend-auth/src/firebaseAdmin.js
+++ b/backend-auth/src/firebaseAdmin.js
@@ -1,0 +1,21 @@
+const admin = require("firebase-admin");
+const fs = require("fs");
+
+function initFirebaseAdmin() {
+  if (admin.apps.length) return admin;
+
+  const p = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+
+  if (!p) throw new Error("Falta FIREBASE_SERVICE_ACCOUNT_PATH en .env");
+
+  const raw = fs.readFileSync(p, "utf8");
+  const sa = JSON.parse(raw);
+
+  admin.initializeApp({
+    credential: admin.credential.cert(sa),
+  });
+
+  return admin;
+}
+
+module.exports = { admin, initFirebaseAdmin };


### PR DESCRIPTION
### Motivation
- Añadir un inicializador reutilizable para Firebase Admin que cargue la clave desde `FIREBASE_SERVICE_ACCOUNT_PATH`, evite reinicializaciones y lance un error claro si falta la configuración.

### Description
- Se agregó `backend-auth/src/firebaseAdmin.js` que exporta `admin` e `initFirebaseAdmin()`, lee el JSON desde la ruta en `FIREBASE_SERVICE_ACCOUNT_PATH`, parsea el service account y llama a `admin.initializeApp({ credential: admin.credential.cert(sa) })` si no hay apps inicializadas.

### Testing
- Ejecutado `node --check backend-auth/src/firebaseAdmin.js`, que pasó la verificación de sintaxis; intentar requerir el módulo falló al ejecutar `node -e "require('./backend-auth/src/firebaseAdmin.js')"` debido a la ausencia local de la dependencia `firebase-admin`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c030f006083208491268f50f7e1bc)